### PR TITLE
Add base theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Course functions and definitions
+ *
+ * @link https://developer.wordpress.org/themes/basics/theme-functions/
+ *
+ * @package Course
+ * @since Course 1.0
+ */
+
+
+if ( ! function_exists( 'course_support' ) ) :
+
+	/**
+	 * Sets up theme defaults and registers support for various WordPress features.
+	 *
+	 * @since Course 1.0
+	 *
+	 * @return void
+	 */
+	function course_support() {
+
+		// Enqueue editor styles.
+		add_editor_style( 'style.css' );
+
+	}
+
+endif;
+
+add_action( 'after_setup_theme', 'course_support' );
+
+if ( ! function_exists( 'course_styles' ) ) :
+
+	/**
+	 * Enqueue styles.
+	 *
+	 * @since Course 1.0
+	 *
+	 * @return void
+	 */
+	function course_styles() {
+
+		// Register theme stylesheet.
+		wp_register_style(
+			'course-style',
+			get_stylesheet_directory_uri() . '/style.css',
+			array(),
+			wp_get_theme()->get( 'Version' )
+		);
+
+		// Enqueue theme stylesheet.
+		wp_enqueue_style( 'course-style' );
+
+	}
+
+endif;
+
+add_action( 'wp_enqueue_scripts', 'course_styles' );

--- a/index.php
+++ b/index.php
@@ -1,0 +1,2 @@
+<?php
+	# This page intentionally left blank

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,0 +1,11 @@
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"80px","bottom":"30px"}}}} -->
+	<div class="wp-block-group" style="padding-top:80px;padding-bottom:30px">
+		<!-- wp:paragraph {"align":"center"} -->
+		<p class="has-text-align-center">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,0 +1,29 @@
+<!-- wp:group {"layout":{"inherit":"true"}} -->
+<div class="wp-block-group">
+	<!-- wp:group {"align":"full","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--preset--spacing--50)","top":"var(--wp--preset--spacing--50)"}}}} -->
+	<div class="wp-block-group alignfull" style="padding-bottom:var(--wp--preset--spacing--50);padding-top:var(--wp--preset--spacing--50)">
+	
+		<!-- wp:group {"layout":{"type":"flex"}} -->
+		<div class="wp-block-group">
+			<!-- wp:site-logo {"width":64} /-->
+	
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}}} -->
+			<div class="wp-block-group">
+				<!-- wp:site-title /-->
+				<!-- wp:site-tagline /-->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:group -->
+	
+		<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+	
+	</div>
+	<!-- /wp:group -->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
+<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->

--- a/parts/post-meta.html
+++ b/parts/post-meta.html
@@ -1,0 +1,12 @@
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+	<!-- wp:group {"layout":{"type":"flex"}} -->
+	<div class="wp-block-group">
+		<!-- wp:post-author {"showAvatar":false,"showBio":false,"style":{"typography":{"fontSize":"14px"}}} /-->
+		<!-- wp:post-date {"isLink":true,"style":{"typography":{"fontSize":"14px"}}} /-->
+		<!-- wp:post-terms {"term":"category","style":{"typography":{"fontSize":"14px"}}} /-->
+		<!-- wp:post-terms {"term": "post_tag","style":{"typography":{"fontSize":"14px"}}} /-->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/patterns/404.php
+++ b/patterns/404.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Title: A 404 page
+ * Slug: course/404
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:heading {"textAlign":"center","level":1,"fontSize":"x-large"} -->
+<h1 class="has-text-align-center has-x-large-font-size" id="oops-that-page-can-t-be-found"><?php echo esc_html__( 'Oops! That page can&rsquo;t be found.', 'course' ); ?></h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php echo  esc_html__( 'It looks like nothing was found at this location. Maybe try a search?', 'course' ); ?></p>
+<!-- /wp:paragraph -->

--- a/patterns/comments.php
+++ b/patterns/comments.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Title: Comments
+ * slug: course/comments
+ * inserter: no
+ */
+
+?>
+
+<!-- wp:comments {"className":"wp-block-comments-query-loop "} -->
+<div class="wp-block-comments wp-block-comments-query-loop"><!-- wp:comments-title {"level":3} /-->
+
+<!-- wp:comment-template -->
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
+<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5em"}}} -->
+<div class="wp-block-group"><!-- wp:avatar {"size":40,"style":{"spacing":{"margin":{"top":"0.5em"}}}} /-->
+
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:comment-author-name /-->
+
+<!-- wp:group {"layout":{"type":"flex"},"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"},"blockGap":"0.5em"}}} -->
+<div class="wp-block-group" style="margin-top:0px;margin-bottom:0px"><!-- wp:comment-date {"format":"F j, Y \\a\\t g:i a"} /-->
+
+<!-- wp:comment-edit-link /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:comment-content /-->
+
+<!-- wp:comment-reply-link /--></div>
+<!-- /wp:group -->
+<!-- /wp:comment-template -->
+
+<!-- wp:comments-pagination -->
+<!-- wp:comments-pagination-previous /-->
+
+<!-- wp:comments-pagination-numbers /-->
+
+<!-- wp:comments-pagination-next /-->
+<!-- /wp:comments-pagination -->
+
+<!-- wp:post-comments-form /--></div>
+<!-- /wp:comments -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,31 @@
+=== Course ===
+Contributors: Automattic
+Requires at least: 5.8
+Tested up to: 5.9
+Requires PHP: 5.7
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+== Description ==
+
+Sensei starter theme
+
+== Changelog ==
+
+= 0.0.1 =
+* Initial release
+
+== Copyright ==
+
+Course WordPress Theme, (C) 2022 Automattic
+Course is distributed under the terms of the GNU GPL.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.

--- a/style.css
+++ b/style.css
@@ -1,0 +1,68 @@
+/*
+Theme Name: Course
+Theme URI: https://github.com/Automattic/sensei-theme
+Author: Automattic
+Author URI: https://automattic.com/
+Description: Sensei starter theme
+Requires at least: 5.8
+Tested up to: 5.9
+Requires PHP: 5.7
+Version: 0.0.1
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Template: 
+Text Domain: course
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+*//*
+ * Font smoothing
+ */
+
+ body {
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-font-smoothing: antialiased;
+}
+
+/*
+ * Responsive menu container padding.
+ * This ensures the responsive container inherits the same
+ * spacing defined above. This behavior may be built into
+ * the Block Editor in the future.
+ */
+
+.wp-block-navigation__responsive-container.is-menu-open {
+	padding-top: var(--wp--preset--spacing--50);
+	padding-bottom: var(--wp--preset--spacing--50);
+	padding-right: var(--wp--preset--spacing--50);
+	padding-left: var(--wp--preset--spacing--50);
+}
+
+/*
+* Control the hover stylings of outline block style.
+* Unnecessary once block styles are configurable via theme.json
+*/
+.wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):hover {
+	background-color: var(--wp--preset--color--secondary);
+	color: var(--wp--preset--color--background);
+	border-color: var(--wp--preset--color--secondary);
+}
+
+/**
+ * Currently table styles are only available with 'wp-block-styles' theme support (block css) thus the following needs to be included
+ * since 'wp-block-styles' aren't used for this theme.
+ */
+.wp-block-table thead {
+	border-bottom: 3px solid;
+}
+.wp-block-table tfoot {
+	border-top: 3px solid;
+}
+.wp-block-table td,
+.wp-block-table th {
+	padding: var(--wp--preset--spacing--30);
+	border: 1px solid;
+	word-break: normal;
+}
+.wp-block-table figcaption {
+	font-size: var(--wp--preset--font-size--small);
+	text-align: center;
+}

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,12 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"},"style":{"spacing":{"blockGap":"var:preset|spacing|50","margin":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|60"}}}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--80);margin-bottom:var(--wp--preset--spacing--60)">
+	
+	<!-- wp:pattern {"slug":"course/404"} /-->
+	<!-- wp:search {"label":""} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,0 +1,33 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
+<main class="wp-block-query">
+<!-- wp:query-title {"type":"archive","style":{"spacing":{"margin":{"bottom":"100px"}}}} /-->
+<!-- wp:post-template -->
+<!-- wp:group -->
+<div class="wp-block-group">
+	<!-- wp:post-title {"isLink":true} /-->
+	<!-- wp:post-featured-image {"isLink":true} /-->
+	<!-- wp:post-excerpt /-->
+	<!-- wp:template-part {"slug":"post-meta","layout":{"inherit":true}} /-->
+	<!-- wp:spacer {"height":40} -->
+	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+</div>
+<!-- /wp:group -->
+<!-- /wp:post-template -->
+<!-- wp:group {"layout":{"inherit":true}} -->
+	<div class="wp-block-group">
+	<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination -->
+	</div>
+	<!-- /wp:group -->
+</main>
+<!-- /wp:query -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/blank.html
+++ b/templates/blank.html
@@ -1,0 +1,1 @@
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,33 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
+<main class="wp-block-query">
+	<!-- wp:post-template -->
+	<!-- wp:group -->
+	<div class="wp-block-group">
+		<!-- wp:post-title {"isLink":true} /-->
+		<!-- wp:post-featured-image {"isLink":true} /-->
+		<!-- wp:post-excerpt /-->
+		<!-- wp:template-part {"slug":"post-meta"} /-->
+		<!-- wp:spacer {"height":40} -->
+		<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
+	</div>
+	<!-- /wp:group -->
+	<!-- /wp:post-template -->
+	<!-- wp:group {"layout":{"inherit":true}} -->
+		<div class="wp-block-group">
+		<!-- wp:query-pagination -->
+			<!-- wp:query-pagination-previous /-->
+	
+			<!-- wp:query-pagination-numbers /-->
+	
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+		</div>
+		<!-- /wp:group -->
+	</main>
+	<!-- /wp:query -->
+	
+	<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+	

--- a/templates/lesson.html
+++ b/templates/lesson.html
@@ -1,0 +1,60 @@
+<!-- wp:group {"className":"sensei-course-theme__header sensei-course-theme__frame sensei-version--4-0-2", "tagName": "header"} -->
+<header class="wp-block-group sensei-course-theme__header sensei-course-theme__frame sensei-version--4-0-2">
+    <!-- wp:columns {"className":"sensei-course-theme__header__container is-not-stacked-on-mobile"} -->
+    <div class="wp-block-columns sensei-course-theme__header__container is-not-stacked-on-mobile">
+        <!-- wp:column {"className":"sensei-course-theme__header__left"} -->
+        <div class="wp-block-column sensei-course-theme__header__left">
+            <!-- wp:site-logo { "width": 50 } /-->
+            <!-- wp:sensei-lms/course-title /-->
+            <!-- wp:sensei-lms/course-theme-course-progress-counter /-->
+        </div>
+        <!-- /wp:column -->
+        <!-- wp:column {"className":"sensei-course-theme__header__navigation"} -->
+        <div class="wp-block-column sensei-course-theme__header__navigation">
+            <!-- wp:sensei-lms/course-theme-prev-next-lesson /-->
+            <!-- wp:sensei-lms/sidebar-toggle-button /-->
+        </div>
+        <!-- /wp:column -->
+        <!-- wp:column {"className":"sensei-course-theme__actions"} -->
+        <div class="wp-block-column sensei-course-theme__actions">
+            <!-- wp:sensei-lms/course-theme-lesson-actions /-->
+        </div>
+        <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+    <!-- wp:sensei-lms/course-theme-course-progress-bar /-->
+</header>
+<!-- /wp:group -->
+<!-- wp:columns {"className":"sensei-course-theme__columns"} -->
+<div class="wp-block-columns sensei-course-theme__columns">
+    <!-- wp:column {"width":"300px","className":"sensei-course-theme__sidebar sensei-course-theme__frame"} -->
+    <div class="wp-block-column sensei-course-theme__sidebar sensei-course-theme__frame" style="flex-basis:300px">
+        <!-- wp:group {"className":"sensei-course-theme__sidebar__content"} -->
+        <div class="wp-block-group sensei-course-theme__sidebar__content">
+            <!-- wp:sensei-lms/focus-mode-toggle /-->
+            <!-- wp:sensei-lms/course-navigation /-->
+        </div>
+        <!-- /wp:group -->
+        <!-- wp:group {"className":"sensei-course-theme__sidebar__footer"} -->
+        <div class="wp-block-group sensei-course-theme__sidebar__footer">
+            <!-- wp:sensei-lms/button-contact-teacher /-->
+            <!-- wp:sensei-lms/exit-course /-->
+        </div>
+        <!-- /wp:group -->
+    </div>
+    <!-- /wp:column -->
+    <!-- wp:column {"width":"","className":"sensei-course-theme__main-content"} -->
+    <div class="wp-block-column sensei-course-theme__main-content">
+        <!-- wp:group {"className":"sensei-course-theme__main-content__container entry-content", "tagName": "main"} -->
+        <main class="wp-block-group sensei-course-theme__main-content__container">
+            <!-- wp:sensei-lms/course-theme-lesson-module /-->
+            <!-- wp:post-title {"level": 1} /-->
+            <!-- wp:sensei-lms/course-theme-notices /-->
+            <!-- wp:post-content /-->
+            <!-- wp:sensei-lms/page-actions /-->
+        </main>
+        <!-- /wp:group -->
+    </div>
+    <!-- /wp:column -->
+</div>
+<!-- /wp:columns -->

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,0 +1,27 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+<!-- wp:post-title /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true}} -->
+<main class="wp-block-group">
+<!-- wp:post-featured-image {"align":"full"} /-->
+
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+    <!-- wp:spacer {"height":60} -->
+    <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+    <!-- /wp:spacer -->
+    <!-- wp:pattern {"slug":"course/comments"} -->
+</div>
+<!-- /wp:pattern -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- /wp:group -->

--- a/templates/quiz.html
+++ b/templates/quiz.html
@@ -1,0 +1,32 @@
+<!-- wp:columns {"className":"sensei-course-theme__quiz__header sensei-course-theme__frame"} -->
+<div class="wp-block-columns sensei-course-theme__quiz__header sensei-course-theme__frame">
+	<!-- wp:column {"className":"sensei-course-theme__quiz__header__left"} -->
+	<div class="wp-block-column sensei-course-theme__quiz__header__left">
+		<!-- wp:sensei-lms/quiz-back-to-lesson /-->
+		<!-- wp:post-title {"level": 1} /-->
+	</div>
+	<!-- /wp:column -->
+	<!-- wp:column {"className":"sensei-course-theme__quiz__header__right"} -->
+	<div class="wp-block-column sensei-course-theme__quiz__header__right">
+		<!-- wp:sensei-lms/quiz-progress /-->
+	</div>
+	<!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
+
+<!-- wp:group {"className":"sensei-course-theme__quiz__main-content", "tagName": "main"} -->
+<main class="wp-block-group sensei-course-theme__quiz__main-content">
+	<!-- wp:sensei-lms/course-theme-notices /-->
+	<!-- wp:post-content /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:group {"className":"sensei-course-theme__quiz__footer_wrapper sensei-course-theme__frame"} -->
+<div class="wp-block-group sensei-course-theme__quiz__footer__wrapper sensei-course-theme__frame">
+	<!-- wp:group {"className":"sensei-course-theme__quiz__footer"} -->
+	<div class="wp-block-group sensei-course-theme__quiz__footer">
+		<!-- wp:sensei-lms/quiz-actions /-->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,39 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group"><!-- wp:search /-->
+
+<!-- wp:spacer {"height":"40px"} -->
+<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group -->
+
+<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null},"layout":{"inherit":true}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:post-title {"isLink":true} /-->
+
+<!-- wp:post-featured-image {"isLink":true} /-->
+
+<!-- wp:post-excerpt /-->
+
+<!-- wp:template-part {"slug":"post-meta"} /-->
+
+<!-- wp:spacer {"height":"40px"} -->
+<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group -->
+<!-- /wp:post-template -->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group"><!-- wp:query-pagination -->
+<!-- wp:query-pagination-previous /-->
+
+<!-- wp:query-pagination-numbers /-->
+
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination --></div>
+<!-- /wp:group --></div>
+<!-- /wp:query -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,0 +1,26 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+<!-- wp:post-title /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true}} -->
+<main class="wp-block-group">
+<!-- wp:post-featured-image {"align":"full"} /-->
+
+<!-- wp:post-content {"layout":{"type":"constrained"},"lock":{"move":false,"remove":true}} /-->
+
+<!-- wp:template-part {"slug":"post-meta"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:spacer {"height":"4rem"} -->
+<div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+<!-- wp:pattern {"slug":"course/comments"} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/theme.json
+++ b/theme.json
@@ -14,27 +14,27 @@
 		"color": {
 			"palette": [
 				{
-					"color": "#007cba",
+					"color": "#007062",
 					"name": "Primary",
 					"slug": "primary"
 				},
 				{
-					"color": "#006ba1",
+					"color": "#cec790",
 					"name": "Secondary",
 					"slug": "secondary"
 				},
 				{
-					"color": "#333333",
+					"color": "#007062",
 					"name": "Foreground",
 					"slug": "foreground"
 				},
 				{
-					"color": "#ffffff",
+					"color": "#f1ede7",
 					"name": "Background",
 					"slug": "background"
 				},
 				{
-					"color": "#F0F0F0",
+					"color": "#f8f5f3",
 					"name": "Tertiary",
 					"slug": "tertiary"
 				}

--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,301 @@
+{
+	"customTemplates": [
+		{
+			"name": "blank",
+			"postTypes": [
+				"page",
+				"post"
+			],
+			"title": "Blank"
+		}
+	],
+	"settings": {
+		"appearanceTools": true,
+		"color": {
+			"palette": [
+				{
+					"color": "#007cba",
+					"name": "Primary",
+					"slug": "primary"
+				},
+				{
+					"color": "#006ba1",
+					"name": "Secondary",
+					"slug": "secondary"
+				},
+				{
+					"color": "#333333",
+					"name": "Foreground",
+					"slug": "foreground"
+				},
+				{
+					"color": "#ffffff",
+					"name": "Background",
+					"slug": "background"
+				},
+				{
+					"color": "#F0F0F0",
+					"name": "Tertiary",
+					"slug": "tertiary"
+				}
+			]
+		},
+		"layout": {
+			"contentSize": "620px",
+			"wideSize": "1000px"
+		},
+		"spacing": {
+			"units": [
+				"%",
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw"
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+					"name": "System Font",
+					"slug": "system-font"
+				}
+			],
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "0.825rem",
+					"slug": "small"
+				},
+				{
+					"fluid": {
+						"max": "1.25rem",
+						"min": "1rem"
+					},
+					"name": "Medium",
+					"size": "1.125rem",
+					"slug": "medium"
+				},
+				{
+					"fluid": false,
+					"name": "Large",
+					"size": "1.75rem",
+					"slug": "large"
+				},
+				{
+					"fluid": {
+						"max": "4rem"
+					},
+					"name": "Extra Large",
+					"size": "3rem",
+					"slug": "x-large"
+				}
+			]
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/code": {
+				"border": {
+					"color": "#CCCCCC",
+					"radius": "0px",
+					"style": "solid",
+					"width": "2px"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "var(--wp--preset--spacing--50)",
+						"left": "var(--wp--preset--spacing--50)",
+						"right": "var(--wp--preset--spacing--50)",
+						"top": "var(--wp--preset--spacing--50)"
+					}
+				},
+				"typography": {
+					"fontFamily": "monospace"
+				}
+			},
+			"core/comment-author-name": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/comment-date": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/comment-edit-link": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/comment-reply-link": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"textDecoration": "underline"
+				}
+			},
+			"core/comments-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"core/gallery": {
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--preset--spacing--50)"
+					}
+				}
+			},
+			"core/list": {
+				"spacing": {
+					"padding": {
+						"left": "var(--wp--preset--spacing--70)"
+					}
+				}
+			},
+			"core/post-date": {
+				"color": {
+					"text": "var(--wp--preset--color--foreground)"
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/post-title": {
+				"spacing": {
+					"margin": {
+						"bottom": "0"
+					}
+				}
+			},
+			"core/pullquote": {
+				"border": {
+					"style": "solid",
+					"width": "1px 0"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "var(--wp--preset--spacing--50)",
+						"left": "var(--wp--preset--spacing--50)",
+						"right": "var(--wp--preset--spacing--50)",
+						"top": "var(--wp--preset--spacing--50)"
+					}
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontStyle": "italic"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"color": "var(--wp--preset--color--primary)",
+					"style": "solid",
+					"width": "0 0 0 1px"
+				},
+				"spacing": {
+					"padding": {
+						"left": "var(--wp--preset--spacing--50)"
+					}
+				},
+				"typography": {
+					"fontStyle": "normal"
+				}
+			},
+			"core/search": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"lineHeight": "1.6"
+				}
+			},
+			"core/separator": {
+				"border": {
+					"color": "currentColor",
+					"style": "solid",
+					"width": "0 0 1px 0"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--foreground)"
+				}
+			},
+			"core/site-tagline": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontWeight": "700",
+					"textDecoration": "none"
+				}
+			}
+		},
+		"color": {
+			"background": "var(--wp--preset--color--background)",
+			"text": "var(--wp--preset--color--foreground)"
+		},
+		"elements": {
+			"h1": {
+				"typography": {
+					"fontSize": "3rem"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontSize": "1.125rem"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--primary)"
+				}
+			}
+		},
+		"spacing": {
+			"blockGap": "1.5rem",
+			"padding": {
+				"left": "var(--wp--preset--spacing--50)",
+				"right": "var(--wp--preset--spacing--50)"
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--system-font)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.6"
+		}
+	},
+	"templateParts": [
+		{
+			"area": "header",
+			"name": "header"
+		},
+		{
+			"area": "footer",
+			"name": "footer"
+		}
+	],
+	"version": 2,
+	"$schema": "https://schemas.wp.org/wp/6.0/theme.json"
+}


### PR DESCRIPTION
Implements #1 and #2.

- Add a base theme based on the [Block Canvas](https://github.com/Automattic/themes/tree/trunk/block-canvas) starter theme. Block Canvas is a full-site editing theme that comes with a set of minimal templates and design settings that can be manipulated through Global Styles. The Theme team uses this team as their starter block theme.
- Set the theme colors.

## Testing Instructions
1. Go to _Appearance_ > _Themes_.
2. Click the _Activate_ button for the Course theme.
3. Check that the site has switched to the Course theme.
4. Check that the theme's colors are applied by publishing a page containing some text. The text color should be `#007062` and the background color should be `#f1ede7`.

## Screenshot
![Screen Shot 2022-10-02 at 11 09 34 AM](https://user-images.githubusercontent.com/1190420/193461325-3cf0dfe6-245f-4089-8d16-20094e1b8203.jpg)