### PR TITLE
Merge Canvas Block theme recent changes - links 

### DIFF
--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,11 +1,1 @@
-<!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group">
-	<!-- wp:group {"style":{"spacing":{"padding":{"top":"80px","bottom":"30px"}}}} -->
-	<div class="wp-block-group" style="padding-top:80px;padding-bottom:30px">
-		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-		<!-- /wp:paragraph -->
-	</div>
-	<!-- /wp:group -->
-</div>
-<!-- /wp:group -->
+<!-- wp:pattern {"slug":"block-canvas/footer"} /-->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,29 +1,21 @@
 <!-- wp:group {"layout":{"inherit":"true"}} -->
 <div class="wp-block-group">
-	<!-- wp:group {"align":"full","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--preset--spacing--50)","top":"var(--wp--preset--spacing--50)"}}}} -->
-	<div class="wp-block-group alignfull" style="padding-bottom:var(--wp--preset--spacing--50);padding-top:var(--wp--preset--spacing--50)">
-	
-		<!-- wp:group {"layout":{"type":"flex"}} -->
-		<div class="wp-block-group">
-			<!-- wp:site-logo {"width":64} /-->
-	
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|60","top":"var:preset|spacing|60","right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--40)"><!-- wp:group {"layout":{"type":"flex"}} -->
+		<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
+
 			<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}}} -->
-			<div class="wp-block-group">
-				<!-- wp:site-title /-->
-				<!-- wp:site-tagline /-->
-			</div>
-			<!-- /wp:group -->
-		</div>
+			<div class="wp-block-group"><!-- wp:site-title /-->
+
+				<!-- wp:site-tagline /--></div>
+			<!-- /wp:group --></div>
 		<!-- /wp:group -->
-	
-		<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
-	
-	</div>
+		<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 	<!-- /wp:group -->
 
 </div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
-<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var(--wp--preset--spacing--80)"} -->
+<div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/parts/post-meta.html
+++ b/parts/post-meta.html
@@ -1,12 +1,10 @@
-<!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
 	<!-- wp:group {"layout":{"type":"flex"}} -->
 	<div class="wp-block-group">
-		<!-- wp:post-author {"showAvatar":false,"showBio":false,"style":{"typography":{"fontSize":"14px"}}} /-->
-		<!-- wp:post-date {"isLink":true,"style":{"typography":{"fontSize":"14px"}}} /-->
-		<!-- wp:post-terms {"term":"category","style":{"typography":{"fontSize":"14px"}}} /-->
-		<!-- wp:post-terms {"term": "post_tag","style":{"typography":{"fontSize":"14px"}}} /-->
+		<!-- wp:post-author-name {"isLink":true,"fontSize":"small"} /-->
+		<!-- wp:post-date {"isLink":true,"fontSize":"small"} /-->
+		<!-- wp:post-terms {"term":"category","fontSize":"small"} /-->
+		<!-- wp:post-terms {"term": "post_tag","fontSize":"small"} /-->
 	</div>
 	<!-- /wp:group -->
 </div>
-<!-- /wp:group -->

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Title: Default footer
+ * Slug: block-canvas/footer
+ * Categories: footer
+ * Block Types: core/template-part/footer
+ */
+?>
+
+<!-- wp:spacer {"height":"var(--wp--preset--spacing--80)"} -->
+<div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+    <!-- wp:group {"style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--60)","bottom":"var(--wp--preset--spacing--60)"}}}} -->
+    <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+        <!-- wp:paragraph {"align":"center"} -->
+        <p class="has-text-align-center">
+            <?php
+            /* Translators: WordPress link. */
+            $wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'block-canvas' ) ) . '" rel="nofollow">WordPress</a>';
+            echo sprintf(
+                esc_html__( 'Proudly Powered by %1$s', 'block-canvas' ),
+                $wordpress_link
+            );
+            ?>
+        </p>
+        <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Course ===
 Contributors: Automattic
-Requires at least: 5.8
+Requires at least: 6.0
 Tested up to: 5.9
 Requires PHP: 5.7
 License: GPLv2 or later

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/Automattic/sensei-theme
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Sensei starter theme
-Requires at least: 5.8
+Requires at least: 6.0
 Tested up to: 5.9
 Requires PHP: 5.7
 Version: 0.0.1
@@ -65,4 +65,12 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 .wp-block-table figcaption {
 	font-size: var(--wp--preset--font-size--small);
 	text-align: center;
+}
+
+/*
+ * Link styles
+ */
+a {
+	text-decoration-thickness: .0625em !important;
+	text-underline-offset: .15em
 }

--- a/theme.json
+++ b/theme.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://schemas.wp.org/wp/6.0/theme.json",
-  "version": 2,
+  	"$schema": "https://schemas.wp.org/wp/6.0/theme.json",
+  	"version": 2,
 	"customTemplates": [
 		{
 			"name": "blank",
@@ -13,6 +13,7 @@
 	],
 	"settings": {
 		"appearanceTools": true,
+		"useRootPaddingAwareAlignments": true,
 		"color": {
 			"palette": [
 				{
@@ -75,47 +76,47 @@
 					"name": "League Gothic",
 					"slug": "league-lothic"
 				},
-        {
-          "fontFace": [
-            {
-							"fontDisplay": "block",
-							"fontFamily": "EB Garamond",
-							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"fontWeight": "200 800",
-							"src": [
-								"file:./assets/fonts/ebgaramond-regular.woff2"
-							]
-            }
-          ],
-          "fontFamily": "\"EB Garamond\", serif",
-					"name": "EB Garamond",
-					"slug": "eb-garamond"
-        }
+				{
+				  "fontFace": [
+					{
+									"fontDisplay": "block",
+									"fontFamily": "EB Garamond",
+									"fontStretch": "normal",
+									"fontStyle": "normal",
+									"fontWeight": "200 800",
+									"src": [
+										"file:./assets/fonts/ebgaramond-regular.woff2"
+									]
+					}
+				  ],
+				  "fontFamily": "\"EB Garamond\", serif",
+							"name": "EB Garamond",
+							"slug": "eb-garamond"
+				}
 			],
 			"fontSizes": [
 				{
-          "name": "Extra small",
+          		"name": "Extra small",
 					"size": "1rem",
 					"slug": "x-small"
 				},
 				{
-          "name": "Small",
+         		 "name": "Small",
 					"size": "1.125rem",
 					"slug": "small"
 				},
 				{
-          "name": "Medium",
+         		 "name": "Medium",
 					"size": "1.3rem",
 					"slug": "medium"
 				},
 				{
-          "name": "Large",
+          		"name": "Large",
 					"size": "1.75rem",
 					"slug": "large"
 				},
 				{
-          "name": "Extra Large",
+          		"name": "Extra Large",
 					"size": "6rem",
 					"slug": "x-large"
 				}
@@ -160,13 +161,7 @@
 			},
 			"core/comment-reply-link": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"textDecoration": "underline"
-				}
-			},
-			"core/comments-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/gallery": {
@@ -183,18 +178,70 @@
 					}
 				}
 			},
+			"core/navigation": {
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
+			"core/post-author-name": {
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
 			"core/post-date": {
 				"color": {
 					"text": "var(--wp--preset--color--foreground)"
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
 				}
 			},
 			"core/post-title": {
 				"spacing": {
 					"margin": {
 						"bottom": "0"
+					}
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
 					}
 				}
 			},
@@ -257,66 +304,123 @@
 					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontWeight": "700",
 					"textDecoration": "none"
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
 				}
 			},
-      "core/paragraph": {
-        	"typography": {
-            "fontFamily": "var(--wp--preset--font-family--eb-garamond)",
-			      "fontSize": "clamp(1.313rem, 2vw + 0.5rem, 1.5rem)",
-			      "lineHeight": "1.838rem"
-          }
-      }
+			"core/paragraph": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontSize": "clamp(1.313rem, 2vw + 0.5rem, 1.5rem)",
+					"lineHeight": "1.838rem"
+				}
+			}
 		},
 		"color": {
 			"background": "var(--wp--preset--color--background)",
 			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
+			"button": {
+				"border": {
+					"radius": "0.25rem"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--primary)",
+					"text": "var(--wp--preset--color--background)"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--secondary)",
+						"text": "var(--wp--preset--color--background)"
+					}
+				},
+				":active": {
+					"color": {
+						"background": "var(--wp--preset--color--primary)",
+						"text": "var(--wp--preset--color--background)"
+					}
+				},
+				":focus": {
+					"color": {
+						"background": "var(--wp--preset--color--primary)",
+						"text": "var(--wp--preset--color--background)"
+					},
+					"outline": {
+						"color": "var(--wp--preset--color--primary)",
+						"offset": "2px",
+						"style": "dotted",
+						"width": "1px"
+					}
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--rubik)",
+					"fontWeight": "400",
+					"lineHeight": "1.125"
+				}
+			},
 			"h1": {
 				"typography": {
-          "fontFamily": "var(--wp--preset--font-family--league-lothic)",
+					"fontFamily": "var(--wp--preset--font-family--league-lothic)",
 					"fontSize": "clamp(3rem, 5vw + 1.5rem, 6.029rem)",
-          "fontWeight": "400",
-          "textTransform": "uppercase",
-          "lineHeight": "96%"
+					"fontWeight": "400",
+					"textTransform": "uppercase",
+					"lineHeight": "96%"
 				}
 			},
 			"h2": {
 				"typography": {
-          "fontFamily": "var(--wp--preset--font-family--league-lothic)",
+					"fontFamily": "var(--wp--preset--font-family--league-lothic)",
 					"fontSize": "clamp(2rem, 2vw + 1.5rem, 3rem)",
-          "lineHeight": "96%"
+          			"lineHeight": "96%"
 				}
 			},
 			"h3": {
 				"typography": {
-          "fontFamily": "var(--wp--preset--font-family--league-lothic)",
-          "fontSize": "clamp(1.5rem, 2vw + 1.5rem, 2.25rem)"
+          			"fontFamily": "var(--wp--preset--font-family--league-lothic)",
+          			"fontSize": "clamp(1.5rem, 2vw + 1.5rem, 2.25rem)"
 				}
 			},
 			"h4": {
 				"typography": {
-          "fontFamily": "var(--wp--preset--font-family--league-lothic)",
+          			"fontFamily": "var(--wp--preset--font-family--league-lothic)",
 					"fontSize": "clamp(1.25rem, 2vw + 1.5rem, 1.5rem)"
 				}
 			},
 			"h5": {
 				"typography": {
-          "fontFamily": "var(--wp--preset--font-family--league-lothic)",
-          "fontSize": "clamp(1.22rem, 2vw + 1.5rem, 1.25rem)"
+          			"fontFamily": "var(--wp--preset--font-family--league-lothic)",
+          			"fontSize": "clamp(1.22rem, 2vw + 1.5rem, 1.25rem)"
 				}
 			},
 			"h6": {
 				"typography": {
-          "fontFamily": "var(--wp--preset--font-family--league-lothic)",
-          "fontSize": "clamp(1.10rem, 2vw + 1.5rem, 1.22rem)"
+					"fontFamily": "var(--wp--preset--font-family--league-lothic)",
+					"fontSize": "clamp(1.10rem, 2vw + 1.5rem, 1.22rem)"
 				}
 			},
 			"link": {
 				"color": {
 					"text": "var(--wp--preset--color--primary)"
+				},
+				":hover": {
+					"typography": {
+						"textDecoration": "none"
+					}
 				}
-			}  
+			}
 		},
 		"spacing": {
 			"blockGap": "1.5rem",


### PR DESCRIPTION
Fixes #16 

This PR is merging the latest changes from Block Canvas [PR ](https://github.com/Automattic/themes/pull/6640) 

This PR is created manually by comparing the changes and adding changes, making sure nothing that worked before is messed up. 

Note some changes are SKIPPED since we have implemented our own: 
- Updates spacing to match Figma definition
- Updates typography of headings

**Important note:** 
This change Updates min WP version to 6.0
Also, I've checked and for me, it was working only when I updated on 6.1

The new changes from Block Canvas

1. Underline on hover for the Header and Header navigation: 

https://user-images.githubusercontent.com/7208249/194382523-654af0f6-5b8a-4ca9-89cc-7a34ac0ba180.mov

2. Links within paragraphs, post tags and categories: underline on default, no underline on hover

https://user-images.githubusercontent.com/7208249/194384691-d2c25b1f-644d-4075-ae30-a9f86e80fe76.mov

3. Post-Author: underline by default and not on hover: 

https://user-images.githubusercontent.com/7208249/194492654-986ff299-5c39-4195-a2a9-4273587f9604.mov

4. Button - change the color on hover

https://user-images.githubusercontent.com/7208249/194494333-5fa9403d-6626-4c18-9ad3-58e36e085426.mov

5. Comment links - underline and no underline on hover

https://user-images.githubusercontent.com/7208249/194495431-bf172d0f-0f63-4795-b615-a2683ceb3875.mov


6. post date: no underline on default, underline on hover

https://user-images.githubusercontent.com/7208249/194496236-bcbdf8af-7e5d-4e20-aefb-12ea8a7e5d07.mov

7. Post title underline on hover

https://user-images.githubusercontent.com/7208249/194500329-c41acbf5-e472-4e73-bc6f-33a4f2a50785.mov

