### PR TITLE
Merge block canvas changes to latest trunk

### DIFF
--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,11 +1,1 @@
-<!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group">
-	<!-- wp:group {"style":{"spacing":{"padding":{"top":"80px","bottom":"30px"}}}} -->
-	<div class="wp-block-group" style="padding-top:80px;padding-bottom:30px">
-		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-		<!-- /wp:paragraph -->
-	</div>
-	<!-- /wp:group -->
-</div>
-<!-- /wp:group -->
+<!-- wp:pattern {"slug":"course/footer"} /-->

--- a/parts/header.html
+++ b/parts/header.html
@@ -2,11 +2,11 @@
 <div class="wp-block-group">
 	<!-- wp:group {"align":"full","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--preset--spacing--50)","top":"var(--wp--preset--spacing--50)"}}}} -->
 	<div class="wp-block-group alignfull" style="padding-bottom:var(--wp--preset--spacing--50);padding-top:var(--wp--preset--spacing--50)">
-	
+
 		<!-- wp:group {"layout":{"type":"flex"}} -->
 		<div class="wp-block-group">
 			<!-- wp:site-logo {"width":64} /-->
-	
+
 			<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}}} -->
 			<div class="wp-block-group">
 				<!-- wp:site-title /-->
@@ -14,9 +14,9 @@
 			<!-- /wp:group -->
 		</div>
 		<!-- /wp:group -->
-	
+
 		<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"1.25rem"}}} /-->
-	
+
 	</div>
 	<!-- /wp:group -->
 

--- a/parts/post-meta.html
+++ b/parts/post-meta.html
@@ -1,12 +1,10 @@
-<!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
 	<!-- wp:group {"layout":{"type":"flex"}} -->
 	<div class="wp-block-group">
-		<!-- wp:post-author {"showAvatar":false,"showBio":false,"style":{"typography":{"fontSize":"14px"}}} /-->
-		<!-- wp:post-date {"isLink":true,"style":{"typography":{"fontSize":"14px"}}} /-->
-		<!-- wp:post-terms {"term":"category","style":{"typography":{"fontSize":"14px"}}} /-->
-		<!-- wp:post-terms {"term": "post_tag","style":{"typography":{"fontSize":"14px"}}} /-->
+		<!-- wp:post-author-name {"isLink":true,"fontSize":"small"} /-->
+		<!-- wp:post-date {"isLink":true,"fontSize":"small"} /-->
+		<!-- wp:post-terms {"term":"category","fontSize":"small"} /-->
+		<!-- wp:post-terms {"term": "post_tag","fontSize":"small"} /-->
 	</div>
 	<!-- /wp:group -->
 </div>
-<!-- /wp:group -->

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Title: Default footer
+ * Slug: course/footer
+ * Categories: footer
+ * Block Types: core/template-part/footer
+ */
+?>
+
+<!-- wp:spacer {"height":"var(--wp--preset--spacing--80)"} -->
+<div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+    <!-- wp:group {"style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--60)","bottom":"var(--wp--preset--spacing--60)"}}}} -->
+    <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+        <!-- wp:paragraph {"align":"center"} -->
+        <p class="has-text-align-center">
+            <?php
+            /* Translators: WordPress link. */
+            $wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'course' ) ) . '" rel="nofollow">WordPress</a>';
+            echo sprintf(
+                esc_html__( 'Proudly Powered by %1$s', 'course' ),
+                $wordpress_link
+            );
+            ?>
+        </p>
+        <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Course ===
 Contributors: Automattic
-Requires at least: 5.8
+Requires at least: 6.1
 Tested up to: 5.9
 Requires PHP: 5.7
 License: GPLv2 or later

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/Automattic/sensei-theme
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Sensei starter theme
-Requires at least: 5.8
+Requires at least: 6.1
 Tested up to: 5.9
 Requires PHP: 5.7
 Version: 0.0.1
@@ -146,4 +146,12 @@ header {
 /* No background color needed as per design when the navbar is being sticky on top */
 header:not(.is-being-sticky) {
 	background-color: transparent;
+}
+
+/*
+ * Link styles
+ */
+a {
+	text-decoration-thickness: .0625em !important;
+	text-underline-offset: .15em
 }

--- a/theme.json
+++ b/theme.json
@@ -149,8 +149,8 @@
 		"blocks": {
 			"core/code": {
 				"border": {
-					"color": "#CCCCCC",
-					"radius": "0px",
+					"color": "var(--wp--preset--color--foreground)",
+					"radius": "0.25rem",
 					"style": "solid",
 					"width": "2px"
 				},
@@ -183,13 +183,7 @@
 			},
 			"core/comment-reply-link": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"textDecoration": "underline"
-				}
-			},
-			"core/comments-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/gallery": {
@@ -207,13 +201,36 @@
 				}
 			},
 			"core/navigation": {
-				"typography": {
-					"textTransform": "uppercase",
-					"fontWeight": "400",
-					"textDecoration": "none",
-					"fontFamily": "var(--wp--preset--font-family--league-gothic)",
-					"fontSize": "var(--wp--preset--font-size--nav-medium)",
-					"lineHeight": "1.5rem"
+				"elements": {
+					"link": {
+						"typography": {
+							"textTransform": "uppercase",
+							"fontWeight": "400",
+							"textDecoration": "none",
+							"fontFamily": "var(--wp--preset--font-family--league-gothic)",
+							"fontSize": "var(--wp--preset--font-size--nav-medium)",
+							"lineHeight": "1.5rem"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
+			"core/post-author-name": {
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
 				}
 			},
 			"core/post-date": {
@@ -222,6 +239,18 @@
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
 				}
 			},
 			"core/post-title": {
@@ -229,10 +258,23 @@
 					"margin": {
 						"bottom": "0"
 					}
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
 				}
 			},
 			"core/pullquote": {
 				"border": {
+					"color": "var(--wp--preset--color--foreground)",
 					"style": "solid",
 					"width": "1px 0"
 				},
@@ -297,6 +339,11 @@
 					"link": {
 						"typography": {
 							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
 						}
 					}
 				}
@@ -314,6 +361,46 @@
 			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
+			"button": {
+				"border": {
+					"radius": "0.25rem"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--primary)",
+					"text": "var(--wp--preset--color--background)"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--secondary)",
+						"text": "var(--wp--preset--color--background)"
+					}
+				},
+				":active": {
+					"color": {
+						"background": "var(--wp--preset--color--primary)",
+						"text": "var(--wp--preset--color--background)"
+					}
+				},
+				":focus": {
+					"color": {
+						"background": "var(--wp--preset--color--primary)",
+						"text": "var(--wp--preset--color--background)"
+					},
+					"outline": {
+						"color": "var(--wp--preset--color--primary)",
+						"offset": "2px",
+						"style": "dotted",
+						"width": "1px"
+					}
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--rubik)",
+					"fontWeight": "400",
+					"lineHeight": "1.125"
+				}
+			},
 			"h1": {
 				"typography": {
           "fontFamily": "var(--wp--preset--font-family--league-gothic)",
@@ -357,8 +444,13 @@
 			"link": {
 				"color": {
 					"text": "var(--wp--preset--color--primary)"
+				},
+				":hover": {
+					"typography": {
+						"textDecoration": "none"
+					}
 				}
-			}  
+			}
 		},
 		"spacing": {
 			"blockGap": "2.5rem",

--- a/theme.json
+++ b/theme.json
@@ -418,7 +418,7 @@
 			},
 			"heading": {
 				"typography": {
-						"fontFamily": "var(--wp--preset--font-family--league-gothic)"
+					"fontFamily": "var(--wp--preset--font-family--league-gothic)",
 					"fontWeight": "400",
 					"lineHeight": "1.125"
 				}


### PR DESCRIPTION
**IMPORTANT NOTE**

This PR is a new PR on the same ticket as [this closed one](https://github.com/Automattic/sensei-theme/pull/22)

Fixes #16 

This PR is merging the latest changes from Block Canvas [PR ](https://github.com/Automattic/themes/pull/6640) 

This PR is created manually by comparing the changes and adding changes, making sure nothing that worked before is messed up. 

Note some changes are SKIPPED since we have implemented our own: 
- Updates spacing to match Figma definition
- Updates typography of headings

**Important note:** 
This change Updates min WP version to 6.0
Also, I've checked and for me, it was working only when I updated on 6.1

The new changes from Block Canvas

1. Underline on hover for the Header and Header navigation: 

https://user-images.githubusercontent.com/7208249/194382523-654af0f6-5b8a-4ca9-89cc-7a34ac0ba180.mov

2. Links within paragraphs, post tags and categories: underline on default, no underline on hover

https://user-images.githubusercontent.com/7208249/194384691-d2c25b1f-644d-4075-ae30-a9f86e80fe76.mov

3. Post-Author: underline by default and not on hover: 

https://user-images.githubusercontent.com/7208249/194492654-986ff299-5c39-4195-a2a9-4273587f9604.mov

4. Button - change the color on hover

https://user-images.githubusercontent.com/7208249/194494333-5fa9403d-6626-4c18-9ad3-58e36e085426.mov

5. Comment links - underline and no underline on hover

https://user-images.githubusercontent.com/7208249/194495431-bf172d0f-0f63-4795-b615-a2683ceb3875.mov


6. post date: no underline on default, underline on hover

https://user-images.githubusercontent.com/7208249/194496236-bcbdf8af-7e5d-4e20-aefb-12ea8a7e5d07.mov

7. Post title underline on hover

https://user-images.githubusercontent.com/7208249/194500329-c41acbf5-e472-4e73-bc6f-33a4f2a50785.mov

