### PR TITLE
Remove duplicated font size

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -2,7 +2,7 @@
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
-<!-- wp:post-title /-->
+<!-- wp:post-title {"level":1} /-->
 </div>
 <!-- /wp:group -->
 

--- a/theme.json
+++ b/theme.json
@@ -128,11 +128,6 @@
 				},
 				{
 					"name": "Small",
-					"size": "1.125rem",
-					"slug": "small"
-				},
-				{
-					"name": "Medium",
 					"size": "clamp(1.25rem, 2vw + 1.5rem, 1.5rem)",
 					"slug": "small"
 				},
@@ -202,22 +197,22 @@
 			},
 			"core/comment-author-name": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--x-small)"
 				}
 			},
 			"core/comment-date": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--x-small)"
 				}
 			},
 			"core/comment-edit-link": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--x-small)"
 				}
 			},
 			"core/comment-reply-link": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--preset--font-size--x-small)",
 					"textDecoration": "underline"
 				}
 			},
@@ -279,7 +274,7 @@
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--system)",
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--xx-small)"
 				},
 				"elements": {
 					"link": {
@@ -383,7 +378,7 @@
 			},
 			"core/site-tagline": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--x-small)"
 				}
 			},
 			"core/site-title": {
@@ -469,7 +464,7 @@
 			},
 			"h3": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)"
+					"fontSize": "var(--wp--preset--font-size--large)"
 				}
 			},
 			"h4": {
@@ -507,7 +502,7 @@
 		},
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
+			"fontSize": "var(--wp--preset--font-size--small)",
 			"lineHeight": "1.838rem"
 		}
 	},


### PR DESCRIPTION
## Changes
Probably due merge conflicts, we have two font sizes with the name medium and two with the slug "small", it was leading us to display wrong font-sizes.

It is fixing and adjusting the font size used.

https://github.com/Automattic/sensei-theme/blob/5fbf25459292dc5ec401bbb67775f6b42631d194/theme.json#L129-L144

### Testing instructions:
Create a page with this content:
```
<!-- wp:post-date /-->

<!-- wp:heading {"level":1} -->
<h1>I am THE H1 TAG (96px)</h1>
<!-- /wp:heading -->

<!-- wp:heading -->
<h2>I am the H2 tag (48px)</h2>
<!-- /wp:heading -->

<!-- wp:heading {"level":3} -->
<h3>I am the H3 (36px)</h3>
<!-- /wp:heading -->

<!-- wp:heading {"level":4} -->
<h4>I am the H4 (24PX)</h4>
<!-- /wp:heading -->

<!-- wp:heading {"level":5} -->
<h5>I am the h5(20PX)</h5>
<!-- /wp:heading -->

<!-- wp:heading {"level":6} -->
<h6>I am the h6 (18X)</h6>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>This blog is run by Professor Jean Biche, Chair of Art History at Sacré-Cœur Université Paris. He joined the Department of Art in 2009 moving from the University of Notredame where he was a Professor of Global History and Culture. (24PX)</p>
<!-- /wp:paragraph -->

<!-- wp:heading {"level":1,"fontSize":"medium"} -->
<h1 class="has-medium-font-size">group/section titles (28px)</h1>
<!-- /wp:heading -->

<!-- wp:heading {"level":1,"fontSize":"x-large"} -->
<h1 class="has-x-large-font-size">posts titles on grid (48px)</h1>
<!-- /wp:heading -->

<!-- wp:heading {"level":1,"fontSize":"xx-large"} -->
<h1 class="has-xx-large-font-size">POST TITLES ON LISTS (64px)</h1>
<!-- /wp:heading -->

<!-- wp:heading {"level":1,"fontSize":"4x-large"} -->
<h1 class="has-4-x-large-font-size">DISPLAY TITLE (136px)</h1>
<!-- /wp:heading -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Ola mundo</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

Check if the font size is equal to the value described inside the parenthesis. 
<img width="1149" alt="Screen Shot 2022-10-12 at 16 27 40" src="https://user-images.githubusercontent.com/38718/195430860-9cd3d6ca-6a92-4a2d-bde8-3f1934240275.png">



