### PR TITLE
Update Course Overview link style

### DIFF
--- a/style.css
+++ b/style.css
@@ -331,3 +331,10 @@ body .is-layout-flow .wp-block-group {
 	padding-right: 4.5rem;
 	padding-left: 4.5rem;
 }
+
+/*
+* Sensei Blocks
+*/
+.wp-block-sensei-lms-course-overview a {
+	text-decoration: underline;
+}

--- a/style.css
+++ b/style.css
@@ -260,30 +260,14 @@ a {
 	text-underline-offset: .15em
 }
 
-a:link {
-	text-decoration: none;
-}
-
-a:hover {
-	text-decoration: underline;
-}
-
-a:focus {
-	text-decoration: underline dotted;
-}
-
-a:active {
-	text-decoration: none;
-	background-color: var(--wp--preset--color--secondary);
-}
 /* Reduce the default vertical distance between elements when inside a layout flow */
 body .is-layout-flow > * + * {
-    margin-block-start: 0.5rem;
+		margin-block-start: 0.5rem;
 }
 
 /* Increase the default vertical distance between elements when inside a layout flow */
 body .is-layout-flow .wp-block-group {
-   margin-block-end: 5rem;
+	margin-block-end: 5rem;
 }
 
 /*

--- a/style.css
+++ b/style.css
@@ -262,7 +262,7 @@ a {
 
 /* Reduce the default vertical distance between elements when inside a layout flow */
 body .is-layout-flow > * + * {
-		margin-block-start: 0.5rem;
+	margin-block-start: 0.5rem;
 }
 
 /* Increase the default vertical distance between elements when inside a layout flow */

--- a/theme.json
+++ b/theme.json
@@ -602,9 +602,25 @@
 				"color": {
 					"text": "var(--wp--preset--color--primary)"
 				},
-				":hover": {
+				"typography": {
+					"textDecoration": "none"
+				},
+				":active": {
+					"color": {
+						"background": "var(--wp--preset--color--secondary)"
+					},
 					"typography": {
 						"textDecoration": "none"
+					}
+				},
+				":focus": {
+					"typography": {
+						"textDecoration": "underline dotted"
+					}
+				},
+				":hover": {
+					"typography": {
+						"textDecoration": "underline"
 					}
 				}
 			}


### PR DESCRIPTION
- Move the link styles from `style.css` to `theme.json`.
- Underline the Course Overview link in the Course Overview block. I had to use custom CSS for this as the following didn't work when I added it to `theme.json`:
```
"sensei-lms/course-overview": {
    "elements": {
	"link": {
            "typography": {
                "textDecoration": "underline"
            }
	}
    }
}
```
 @pbking @jeffikus @mikachan any idea why the above doesn't work in `theme.json`? The markup for the block is:
```
<div class="wp-block-sensei-lms-course-overview"><a href="http://senseitheme.local/course/not-started-course/">Course Overview</a></div>
```

## Testing Instructions

- Add a paragraph block to a page.
- Add some text and add a link in the paragraph.
- View the page on the frontend.
- Ensure the link styles for each state are as per the [design](https://www.figma.com/file/nf4oV51c1JBxJKXshMe7cd/New-Sensei-Theme?node-id=20020042%3A329).
- The Course Overview link style can be tested as part of https://github.com/Automattic/sensei/pull/5996.