### PR TITLE
Fix button styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -292,6 +292,12 @@ body .is-layout-flow .wp-block-group {
 	fill: #ffffff;
 }
 
+/* Buttons */
+.wp-block-button__link:focus {
+	outline: var(--wp--preset--color--primary) dashed;
+	outline-offset: 1px;
+}
+
 /*
 * Control the hover stylings of outline block style.
 * Unnecessary once block styles are configurable via theme.json

--- a/style.css
+++ b/style.css
@@ -36,16 +36,6 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 	padding-left: var(--wp--preset--spacing--50);
 }
 
-/*
-* Control the hover stylings of outline block style.
-* Unnecessary once block styles are configurable via theme.json
-*/
-.wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):hover {
-	background-color: var(--wp--preset--color--secondary);
-	color: var(--wp--preset--color--background);
-	border-color: var(--wp--preset--color--secondary);
-}
-
 /**
  * Currently table styles are only available with 'wp-block-styles' theme support (block css) thus the following needs to be included
  * since 'wp-block-styles' aren't used for this theme.
@@ -304,34 +294,21 @@ body .is-layout-flow .wp-block-group {
 */
 .wp-block-buttons .wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):active {
 	background-color: var(--wp--preset--color--secondary);
-	border-color: var(--wp--preset--color--secondary);
+	border-color: var(--wp--custom--button--active--border--color);
 	color: var(--wp--preset--color--primary);
 }
 
-/*
-* Control the hover stylings of outline block style.
-* Unnecessary once block styles are configurable via theme.json
-*/
 .wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):hover {
 	background-color: var(--wp--preset--color--primary);
+	border-color: var(--wp--custom--button--hover--border--color);
 	color: var(--wp--preset--color--secondary);
-	border-color: var(--wp--preset--color--primary);
 }
 
-/*
-* Control the hover stylings of outline block style.
-* Unnecessary once block styles are configurable via theme.json
-*/
 .wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):focus {
-	background-color: var(--wp--preset--color--primary);
-	color: var(--wp--preset--color--background);
 	border-color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--primary);
 }
 
-/*
-* Control the hover stylings of outline block style.
-* Unnecessary once block styles are configurable via theme.json
-*/
 .wp-block-button.is-style-outline>.wp-block-button__link,
 .wp-block-button .wp-block-button__link.is-style-outline {
 	border-width: 1px;

--- a/style.css
+++ b/style.css
@@ -328,8 +328,8 @@ body .is-layout-flow .wp-block-group {
 */
 .wp-block-button.is-style-outline>.wp-block-button__link,
 .wp-block-button .wp-block-button__link.is-style-outline {
-	padding-right: 4.5rem;
-	padding-left: 4.5rem;
+	border-width: 1px;
+	padding: 0.5856em 1.5238em;
 }
 
 /*

--- a/style.css
+++ b/style.css
@@ -294,13 +294,13 @@ body .is-layout-flow .wp-block-group {
 */
 .wp-block-buttons .wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):active {
 	background-color: var(--wp--preset--color--secondary);
-	border-color: var(--wp--custom--button--active--border--color);
+	border-color: var(--wp--preset--color--button-border-active);
 	color: var(--wp--preset--color--primary);
 }
 
 .wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):hover {
 	background-color: var(--wp--preset--color--primary);
-	border-color: var(--wp--custom--button--hover--border--color);
+	border-color: var(--wp--preset--color--button-border-hover);
 	color: var(--wp--preset--color--secondary);
 }
 

--- a/style.css
+++ b/style.css
@@ -321,3 +321,8 @@ body .is-layout-flow .wp-block-group {
 .wp-block-sensei-lms-course-overview a {
 	text-decoration: underline;
 }
+
+.wp-block-sensei-lms-course-list .sensei-cta a:hover,
+.wp-block-sensei-lms-course-list .sensei-cta a:focus {
+	text-decoration: none;
+}

--- a/style.css
+++ b/style.css
@@ -91,7 +91,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 
  /* The navigation item that looks like a button in the design has a different front size and the button is rounded */
  .wp-block-navigation .wp-block-navigation__responsive-container .wp-block-navigation-link.is-style-navigation-link-button a {
-	font-size: var(--wp--preset--font-size--nav-button-link);
+	font-size: var(--wp--preset--font-size--button-link);
 	border-radius: 8px;
 }
 
@@ -167,8 +167,8 @@ header:not(.is-being-sticky) {
 	background-color: var(--wp--preset--color--primary);
 	text-transform: uppercase;
 	font-family: var(--wp--preset--font-family--league-gothic);
-	font-size: var(--wp--preset--font-size--nav-button-link);
-	line-height: var(--wp--preset--font-size--nav-button-link);
+	font-size: var(--wp--preset--font-size--button-link);
+	line-height: var(--wp--preset--font-size--button-link);
 }
 
 .wp-block-post-comments-form form.comment-form p input[type=submit]:hover {

--- a/theme.json
+++ b/theme.json
@@ -516,13 +516,6 @@
 		},
 		"elements": {
 			"button": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--button-link)",
-					"textTransform": "uppercase",
-					"fontWeight": "400",
-					"fontFamily": "var(--wp--preset--font-family--league-gothic)",
-					"letterSpacing": "0.05em",
-				},
 				"border": {
 					"color": "var(--wp--preset--color--primary)",
 					"radius": "8px",
@@ -540,6 +533,13 @@
 						"bottom": "0.5856em",
 						"left": "1.5238em"
 					}
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--league-gothic)",
+					"fontSize": "var(--wp--preset--font-size--button-link)",
+					"fontWeight": "400",
+					"letterSpacing": "0.05em",
+					"textTransform": "uppercase",
 				},
 				":hover": {
 					"outline": {

--- a/theme.json
+++ b/theme.json
@@ -520,14 +520,26 @@
 					"fontSize": "var(--wp--preset--font-size--button-link)",
 					"textTransform": "uppercase",
 					"fontWeight": "400",
-					"fontFamily": "var(--wp--preset--font-family--league-gothic)"
+					"fontFamily": "var(--wp--preset--font-family--league-gothic)",
+					"letterSpacing": "0.05em",
 				},
 				"border": {
-					"radius": "0.5rem"
+					"color": "var(--wp--preset--color--primary)",
+					"radius": "8px",
+					"style": "solid",
+					"width": "1px"
 				},
 				"color": {
 					"background": "var(--wp--preset--color--primary)",
 					"text": "var(--wp--preset--color--background)"
+				},
+				"spacing": {
+					"padding": {
+						"top": "0.5856em",
+						"right": "1.5238em",
+						"bottom": "0.5856em",
+						"left": "1.5238em"
+					}
 				},
 				":hover": {
 					"outline": {

--- a/theme.json
+++ b/theme.json
@@ -48,7 +48,19 @@
 			"replyColumnGap": "2.349rem",
 			"commentGap" : "5rem",
 			"commentGapSmall" : "10px",
-			"commentGapMedium" : "1.25rem"
+			"commentGapMedium" : "1.25rem",
+			"button": {
+				":active": {
+					"border": {
+						"color": "#FFF7BC"
+					}
+				},
+				":hover": {
+					"border": {
+						"color": "#009F8D"
+					}
+				}
+			}
 		},
 		"layout": {
 			"contentSize": "1000px",
@@ -541,16 +553,10 @@
 					"letterSpacing": "0.05em",
 					"textTransform": "uppercase"
 				},
-				":hover": {
-					"outline": {
-						"color": "red"
-					},
-					"color": {
-						"background": "var(--wp--preset--color--primary)",
-						"text": "var(--wp--preset--color--secondary)"
-					}
-				},
 				":active": {
+					"border": {
+						"color": "var(--wp--custom--button--active--border--color)"
+					},
 					"color": {
 						"background": "var(--wp--preset--color--secondary)",
 						"text": "var(--wp--preset--color--primary)"
@@ -560,6 +566,15 @@
 					"color": {
 						"background": "var(--wp--preset--color--primary)",
 						"text": "var(--wp--preset--color--background)"
+					}
+				},
+				":hover": {
+					"border": {
+						"color": "var(--wp--custom--button--hover--border--color)"
+					},
+					"color": {
+						"background": "var(--wp--preset--color--primary)",
+						"text": "var(--wp--preset--color--secondary)"
 					}
 				}
 			},

--- a/theme.json
+++ b/theme.json
@@ -539,7 +539,7 @@
 					"fontSize": "var(--wp--preset--font-size--button-link)",
 					"fontWeight": "400",
 					"letterSpacing": "0.05em",
-					"textTransform": "uppercase",
+					"textTransform": "uppercase"
 				},
 				":hover": {
 					"outline": {

--- a/theme.json
+++ b/theme.json
@@ -39,6 +39,16 @@
 					"color": "#f8f5f3",
 					"name": "Tertiary",
 					"slug": "tertiary"
+				},
+				{
+					"color": "#FFF7BC",
+					"name": "Button Border - Active",
+					"slug": "button-border-active"
+				},
+				{
+					"color": "#009F8D",
+					"name": "Button Border - Hover",
+					"slug": "button-border-hover"
 				}
 			]
 		},
@@ -48,19 +58,7 @@
 			"replyColumnGap": "2.349rem",
 			"commentGap" : "5rem",
 			"commentGapSmall" : "10px",
-			"commentGapMedium" : "1.25rem",
-			"button": {
-				":active": {
-					"border": {
-						"color": "#FFF7BC"
-					}
-				},
-				":hover": {
-					"border": {
-						"color": "#009F8D"
-					}
-				}
-			}
+			"commentGapMedium" : "1.25rem"
 		},
 		"layout": {
 			"contentSize": "1000px",
@@ -555,7 +553,7 @@
 				},
 				":active": {
 					"border": {
-						"color": "var(--wp--custom--button--active--border--color)"
+						"color": "var(--wp--preset--color--button-border-active)"
 					},
 					"color": {
 						"background": "var(--wp--preset--color--secondary)",
@@ -570,7 +568,7 @@
 				},
 				":hover": {
 					"border": {
-						"color": "var(--wp--custom--button--hover--border--color)"
+						"color": "var(--wp--preset--color--button-border-hover)"
 					},
 					"color": {
 						"background": "var(--wp--preset--color--primary)",

--- a/theme.json
+++ b/theme.json
@@ -176,9 +176,9 @@
 					"slug": "nav-medium"
 				},
 				{
-					"name": "Navbar Button Link",
+					"name": "Button Link",
 					"size": "1.3125rem",
-					"slug": "nav-button-link"
+					"slug": "button-link"
 				}
 			]
 		}
@@ -244,8 +244,8 @@
 							"textTransform": "uppercase",
 							"fontWeight": "400",
 							"fontFamily": "var(--wp--preset--font-family--league-gothic)",
-							"fontSize": "var(--wp--preset--font-size--nav-button-link)",
-							"lineHeight": "var(--wp--preset--font-size--nav-button-link)"
+							"fontSize": "var(--wp--preset--font-size--button-link)",
+							"lineHeight": "var(--wp--preset--font-size--button-link)"
 						}
 					}
 				}
@@ -516,14 +516,8 @@
 		},
 		"elements": {
 			"button": {
-				"spacing": {
-					"padding": {
-						"left": "4.5rem",
-						"right": "4.5rem"
-					}
-				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--nav-button-link)",
+					"fontSize": "var(--wp--preset--font-size--button-link)",
 					"textTransform": "uppercase",
 					"fontWeight": "400",
 					"fontFamily": "var(--wp--preset--font-family--league-gothic)"

--- a/theme.json
+++ b/theme.json
@@ -529,7 +529,7 @@
 		"elements": {
 			"button": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
+					"color": "transparent",
 					"radius": "8px",
 					"style": "solid",
 					"width": "1px"


### PR DESCRIPTION
Fix button styles to match the [design](https://www.figma.com/file/nf4oV51c1JBxJKXshMe7cd/New-Sensei-Theme?node-id=20020042%3A329). In particular:

- Button height is 56px.
- Left & right padding is 32px.
- Font size is 21px.
- Letter spacing is 0.05em.
- Fix the button active, hover and focus states.

Note that the button background and text color don't match the design, but this will be addressed in a separate PR.

For the Course List block, remove the link underline from all buttons for all button states.

## Testing Instructions
- Switch to [this branch of](https://github.com/Automattic/sensei/pull/6010) Sensei.
- Add some buttons to a page.
- View the page in the editor and on the frontend and ensure the button styles are correct.
- Add the Course List block to a page.
- View the page in the editor and on the frontend and ensure the button styles are correct and the button text is not underlined for any of the button states.

## Screenshots

### Default
![Screen Shot 2022-10-26 at 10 05 49 AM](https://user-images.githubusercontent.com/1190420/198047919-641694b6-5198-4685-80fa-f0f18e800698.jpg)

### Hover
![Screen Shot 2022-10-26 at 10 06 27 AM](https://user-images.githubusercontent.com/1190420/198048082-87575cbc-d111-4e96-aa08-cbe1c22d1f2f.jpg)

### Focus
![Screen Shot 2022-10-26 at 10 05 25 AM](https://user-images.githubusercontent.com/1190420/198047858-d439bda4-bb35-49b3-b9a4-e8507c65f0e7.jpg)

### Active
![Screen Shot 2022-10-26 at 10 07 12 AM](https://user-images.githubusercontent.com/1190420/198048286-cbe7d1c1-4cc8-4b32-9478-3b04df8b4958.jpg)

### Course List
![Screen Shot 2022-10-26 at 11 28 47 AM](https://user-images.githubusercontent.com/1190420/198069162-fbac1be1-d901-4762-9a8d-bf9bebb44acf.jpg)