### PR TITLE
Update theme colors

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -16,27 +16,27 @@
 		"color": {
 			"palette": [
 				{
-					"color": "#007062",
+					"color": "#00594F",
 					"name": "Primary",
 					"slug": "primary"
 				},
 				{
-					"color": "#cec790",
+					"color": "#F7EFAD",
 					"name": "Secondary",
 					"slug": "secondary"
 				},
 				{
-					"color": "#007062",
+					"color": "#00594F",
 					"name": "Foreground",
 					"slug": "foreground"
 				},
 				{
-					"color": "#f1ede7",
+					"color": "#F1EDE7",
 					"name": "Background",
 					"slug": "background"
 				},
 				{
-					"color": "#f8f5f3",
+					"color": "#F8F5F3",
 					"name": "Tertiary",
 					"slug": "tertiary"
 				}


### PR DESCRIPTION
Apparently the colors in the color palette of the design were not correct. They've been updated as per https://github.com/Automattic/sensei-theme/issues/51.

## Testing Instructions
- View a page on the Sensei theme.
- Ensure the body text is `#00594F`.
- Ensure the body background is `#F1EDE7`.
- Add a link to the page.
- Ensure its color is `#00594F`.
- Set the state of the link to `:active`.
- Ensure its background color is `#F7EFAD`.