### PR TITLE
Remove font family configuration from group

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -379,11 +379,6 @@
 					}
 				}
 			},
-			"core/group": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--league-gothic)"
-				}
-			},
 			"core/list": {
 				"spacing": {
 					"padding": {


### PR DESCRIPTION
### Introduced changes
it is fixing a too-wide configuration that was modifying all typography 


## Steps to Reproduce
- Open the Page editor
- Create a group
- Add a paragraph
- Compare with the screenshot

## What is expected
- The text should look like the image 2

### Before change:
<img width="1058" alt="Screen Shot 2022-10-31 at 18 06 51" src="https://user-images.githubusercontent.com/38718/199110875-e84457a3-345f-4c4b-8f53-26dce477a8a8.png">


### After change:
<img width="997" alt="Screen Shot 2022-10-31 at 18 08 21" src="https://user-images.githubusercontent.com/38718/199110986-57673d82-4b95-4b44-9954-1d90f53a777b.png">


