### PR TITLE
Tweaks to patterns

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -71,3 +71,15 @@ function course_theme_init() {
 }
 
 add_action( 'init', 'course_theme_init' );
+
+/**
+ * Register Sensei LMS block patterns category.
+ */
+function register_block_patterns_category() {
+	register_block_pattern_category(
+		'sensei-lms',
+		[ 'label' => 'Sensei LMS' ]
+	);
+}
+
+add_action( 'init', 'register_block_patterns_category' );

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -2,7 +2,7 @@
 /**
  * Title: Default footer
  * Slug: course/footer
- * Categories: footer
+ * Inserter: no
  * Block Types: core/template-part/footer
  */
 ?>

--- a/patterns/mailing-list.php
+++ b/patterns/mailing-list.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Newsletter
- * Slug: course/newsletter-homepage
+ * Title: Mailing List
+ * Slug: course/mailing-list
  * Inserter: yes
  * Categories: sensei-lms
  */

--- a/patterns/newsletter.php
+++ b/patterns/newsletter.php
@@ -5,18 +5,17 @@
  * Inserter: no
  */
 ?>
+
 <!-- wp:group {"style":{"spacing":{"blockGap":"1.25rem"}},"layout":{"type":"constrained","justifyContent":"left"}} -->
-<div class="wp-block-group">
-<!-- wp:heading {"fontSize":"medium"} -->
-<h2 class="has-medium-font-size"><?php echo esc_html__('NEWSLETTER', 'course');?></h2>
+<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} -->
+<h2 class="has-medium-font-size" style="text-transform:uppercase"><?php echo esc_html__( 'Newsletter', 'course' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><?php echo esc_html__('Our latest updates in your e-mail.', 'course'); ?></p>
+<p><?php echo esc_html__( 'Our latest updates in your e-mail.', 'course' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><a href="#"><?php echo esc_html__('Sign up', 'course'); ?></a></p>
-<!-- /wp:paragraph -->
-</div>
+<p><a href="#"><?php echo esc_html__( 'Sign up', 'course' ); ?></a></p>
+<!-- /wp:paragraph --></div>
 <!-- /wp:group -->

--- a/patterns/newsletter.php
+++ b/patterns/newsletter.php
@@ -1,22 +1,22 @@
-    <?php
-    /**
-     * Title: Newsletter text 
-     * Slug: course/newsletter
-     * Inserter: yes
-     */
-    ?>
-    <!-- wp:group {"style":{"spacing":{"blockGap":"1.25rem"}},"layout":{"type":"constrained","justifyContent":"left"}} -->
-    <div class="wp-block-group">
-      <!-- wp:heading {"fontSize":"medium"} -->
-      <h2 class="has-medium-font-size"><?php echo esc_html__('NEWSLETTER', 'course');?></h2>
-      <!-- /wp:heading -->
+<?php
+/**
+ * Title: Newsletter
+ * Slug: course/newsletter
+ * Inserter: no
+ */
+?>
+<!-- wp:group {"style":{"spacing":{"blockGap":"1.25rem"}},"layout":{"type":"constrained","justifyContent":"left"}} -->
+<div class="wp-block-group">
+<!-- wp:heading {"fontSize":"medium"} -->
+<h2 class="has-medium-font-size"><?php echo esc_html__('NEWSLETTER', 'course');?></h2>
+<!-- /wp:heading -->
 
-      <!-- wp:paragraph -->
-      <p><?php echo esc_html__('Our latest updates in your e-mail.', 'course'); ?></p>
-      <!-- /wp:paragraph -->
+<!-- wp:paragraph -->
+<p><?php echo esc_html__('Our latest updates in your e-mail.', 'course'); ?></p>
+<!-- /wp:paragraph -->
 
-      <!-- wp:paragraph -->
-      <p><a href="#"><?php echo esc_html__('Sign up', 'course'); ?></a></p>
-      <!-- /wp:paragraph -->
-    </div>
-    <!-- /wp:group -->
+<!-- wp:paragraph -->
+<p><a href="#"><?php echo esc_html__('Sign up', 'course'); ?></a></p>
+<!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->

--- a/patterns/search.php
+++ b/patterns/search.php
@@ -2,7 +2,7 @@
 /**
  * Title: Default Search 
  * Slug: course/search
- * Inserter: yes
+ * Inserter: no
  */
 ?>
 


### PR DESCRIPTION
- Remove newsletter, footer and search patterns from the inserter.
- Rename _Newsletter_ pattern to _Mailing List_.
- Register the Sensei LMS block pattern category. Previously, this category was only added when Sensei was installed.
- Set `text-transform` in the block settings for the newsletter pattern so it can be customized easily.

## Testing Instructions
- Deactivate the Sensei plugin and ensure the _Sensei LMS_ block pattern category still appears.
- Open the block pattern inserter and ensure that _Newsletter_, _Default Footer_ and _Default Search_ don't show up when entered in the search box.
- Ensure the _Mailing List_ pattern appears under the _Sensei LMS_ block pattern category.