### PR TITLE
Replace "sensei-theme" references with "course"

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -34,4 +34,4 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"sensei-theme","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","theme":"course","tagName":"footer"} /-->

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"sensei-theme","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","theme":"course","tagName":"header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"20px","left":"20px"}}},"layout":{"type":"constrained","contentSize":"1000px","wideSize":"1200px"}} -->
 <div class="wp-block-group" style="padding-right:20px;padding-left:20px">
@@ -69,4 +69,4 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"sensei-theme","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","theme":"course","tagName":"footer"} /-->


### PR DESCRIPTION
There were a few `sensei-theme` references that were missed in #78. This replaces those with `course`.

## Testing Instructions
Ensure the search and archive templates work in the site editor and on the frontend.

_Archive Template - Before_

![Screenshot 2022-11-10 at 12 02 38 PM](https://user-images.githubusercontent.com/1190420/201159680-0a351b30-d2d9-4b99-bde0-e8f847997413.jpg)

_Archive Template - After_

![Screenshot 2022-11-10 at 12 02 03 PM](https://user-images.githubusercontent.com/1190420/201159548-2809d660-62ca-4069-8812-5d86a4cff8eb.jpg)