### PR TITLE
Fix styles in mailing list and testimonial patterns

### DIFF
--- a/patterns/mailing-list.php
+++ b/patterns/mailing-list.php
@@ -9,13 +9,13 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0px","bottom":"100px","right":"20px","left":"20px"}}},"layout":{"type":"constrained","contentSize":"1000px"}} -->
 <div class="wp-block-group alignfull" style="padding-top:0px;padding-right:20px;padding-bottom:100px;padding-left:20px"><!-- wp:group {"style":{"spacing":{"padding":{"left":"38px","top":"20px","bottom":"20px"}},"border":{"top":{"width":"0px","style":"none"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"color":"var:preset|color|primary"}}},"className":"is-style-group-left-border","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group is-style-group-left-border" style="border-top-style:none;border-top-width:0px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-color:var(--wp--preset--color--primary);padding-top:20px;padding-bottom:20px;padding-left:38px"><!-- wp:heading {"textAlign":"left","style":{"typography":{"textTransform":"uppercase","lineHeight":"1"}},"fontSize":"x-large"} -->
-<h2 class="has-text-align-left has-x-large-font-size" style="line-height:1;text-transform:uppercase">keep track of the latest<br>news and lessons.<br>Every week in your inbox.</h2>
+<div class="wp-block-group is-style-group-left-border" style="border-top-style:none;border-top-width:0px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-color:var(--wp--preset--color--primary);padding-top:20px;padding-bottom:20px;padding-left:38px"><!-- wp:heading {"textAlign":"left","style":{"typography":{"textTransform":"uppercase","lineHeight":"1"}},"fontSize":"x-large","fontFamily":"league-gothic"} -->
+<h2 class="has-text-align-left has-league-gothic-font-family has-x-large-font-size" style="line-height:1;text-transform:uppercase">Keep track of the latest<br>news and lessons.<br>Every week in your inbox.</h2>
 <!-- /wp:heading -->
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right","verticalAlignment":"center"}} -->
-<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"primary","textColor":"tertiary","style":{"border":{"radius":"8px"}},"fontSize":"x-small"} -->
-<div class="wp-block-button has-custom-font-size has-x-small-font-size"><a class="wp-block-button__link has-tertiary-color has-primary-background-color has-text-color has-background wp-element-button" style="border-radius:8px">JOIN OUR MAILING LIST</a></div>
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"primary","textColor":"background","style":{"border":{"radius":"8px"}},"fontSize":"x-small"} -->
+<div class="wp-block-button has-custom-font-size has-x-small-font-size"><a class="wp-block-button__link has-background-color has-primary-background-color has-text-color has-background wp-element-button" style="border-radius:8px">Join Our Mailing List</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>

--- a/patterns/testimonial.php
+++ b/patterns/testimonial.php
@@ -17,7 +17,7 @@
 <!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"35px","left":"35px"},"padding":{"top":"40px"}}}} -->
 <div class="wp-block-columns" style="padding-top:40px"><!-- wp:column {"verticalAlignment":"bottom","width":"41%"} -->
 <div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:41%"><!-- wp:image {"id":2150,"sizeSlug":"full","linkDestination":"none","style":{"border":{"radius":"8px","width":"1px"}}} -->
-<figure class="wp-block-image size-full has-custom-border"><img src="http://senseitheme.local/wp-content/themes/course/assets/images/testimonial.png" alt="" class="wp-image-2150" style="border-width:1px;border-radius:8px"/></figure>
+<figure class="wp-block-image size-full has-custom-border"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/testimonial.png" alt="" class="wp-image-2150" style="border-width:1px;border-radius:8px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 

--- a/patterns/testimonial.php
+++ b/patterns/testimonial.php
@@ -9,8 +9,8 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"120px","right":"20px","left":"20px"},"blockGap":"0px"}},"backgroundColor":"primary","textColor":"background","layout":{"type":"constrained","contentSize":"1000px"}} -->
 <div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background" style="padding-top:80px;padding-right:20px;padding-bottom:120px;padding-left:20px"><!-- wp:group {"style":{"spacing":{"padding":{"left":"20px","bottom":"0px"}},"border":{"top":{"width":"0px","style":"none"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"color":"var:preset|color|tertiary","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group" style="border-top-style:none;border-top-width:0px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-color:var(--wp--preset--color--tertiary);border-left-width:1px;padding-bottom:0px;padding-left:20px"><!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1","letterSpacing":"0.01em"}},"fontSize":"medium","fontFamily":"league-gothic"} -->
-<h3 class="has-league-gothic-font-family has-medium-font-size" style="letter-spacing:0.01em;line-height:1;text-transform:uppercase">What students say</h3>
+<div class="wp-block-group" style="border-top-style:none;border-top-width:0px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-color:var(--wp--preset--color--tertiary);border-left-width:1px;padding-bottom:0px;padding-left:20px"><!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1","letterSpacing":"0.01em"},"spacing":{"padding":{"top":"0px"}}},"fontSize":"medium","fontFamily":"league-gothic"} -->
+<h3 class="has-league-gothic-font-family has-medium-font-size" style="padding-top:0px;letter-spacing:0.01em;line-height:1;text-transform:uppercase">What students say</h3>
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 

--- a/patterns/testimonial.php
+++ b/patterns/testimonial.php
@@ -7,31 +7,31 @@
  */
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"120px","right":"20px","left":"20px"},"blockGap":"0px"}},"backgroundColor":"primary","textColor":"foreground","layout":{"type":"constrained","contentSize":"1000px"}} -->
-<div class="wp-block-group alignfull has-foreground-color has-primary-background-color has-text-color has-background" style="padding-top:80px;padding-right:20px;padding-bottom:120px;padding-left:20px"><!-- wp:group {"style":{"spacing":{"padding":{"left":"20px","bottom":"0px"}},"border":{"top":{"width":"0px","style":"none"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"color":"var:preset|color|tertiary","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group" style="border-top-style:none;border-top-width:0px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-color:var(--wp--preset--color--tertiary);border-left-width:1px;padding-bottom:0px;padding-left:20px"><!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1"}},"textColor":"tertiary","fontSize":"medium"} -->
-<h3 class="has-tertiary-color has-text-color has-medium-font-size" style="line-height:1;text-transform:uppercase">What students say</h3>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"120px","right":"20px","left":"20px"},"blockGap":"0px"}},"backgroundColor":"primary","textColor":"background","layout":{"type":"constrained","contentSize":"1000px"}} -->
+<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background" style="padding-top:80px;padding-right:20px;padding-bottom:120px;padding-left:20px"><!-- wp:group {"style":{"spacing":{"padding":{"left":"20px","bottom":"0px"}},"border":{"top":{"width":"0px","style":"none"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"color":"var:preset|color|tertiary","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group" style="border-top-style:none;border-top-width:0px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-color:var(--wp--preset--color--tertiary);border-left-width:1px;padding-bottom:0px;padding-left:20px"><!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1","letterSpacing":"0.01em"}},"fontSize":"medium","fontFamily":"league-gothic"} -->
+<h3 class="has-league-gothic-font-family has-medium-font-size" style="letter-spacing:0.01em;line-height:1;text-transform:uppercase">What students say</h3>
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
-<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"35px","left":"35px"},"padding":{"top":"40px"}}},"textColor":"tertiary"} -->
-<div class="wp-block-columns has-tertiary-color has-text-color" style="padding-top:40px"><!-- wp:column {"verticalAlignment":"bottom","width":"41%"} -->
+<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"35px","left":"35px"},"padding":{"top":"40px"}}}} -->
+<div class="wp-block-columns" style="padding-top:40px"><!-- wp:column {"verticalAlignment":"bottom","width":"41%"} -->
 <div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:41%"><!-- wp:image {"id":2150,"sizeSlug":"full","linkDestination":"none","style":{"border":{"radius":"8px","width":"1px"}}} -->
-<figure class="wp-block-image size-full has-custom-border"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/testimonial.png" alt="" class="wp-image-2150" style="border-width:1px;border-radius:8px"/></figure>
+<figure class="wp-block-image size-full has-custom-border"><img src="http://senseitheme.local/wp-content/themes/course/assets/images/testimonial.png" alt="" class="wp-image-2150" style="border-width:1px;border-radius:8px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"bottom"} -->
-<div class="wp-block-column is-vertically-aligned-bottom"><!-- wp:heading {"style":{"spacing":{"margin":{"bottom":"40px"}},"typography":{"textTransform":"uppercase","lineHeight":"1"}},"textColor":"tertiary","fontSize":"x-large"} -->
-<h2 class="has-tertiary-color has-text-color has-x-large-font-size" style="margin-bottom:40px;line-height:1;text-transform:uppercase">“I always wanted to write, and<br>thanks to Cours, I got it right. My<br>writing is clearer, and I can finally get my message across.”</h2>
+<div class="wp-block-column is-vertically-aligned-bottom"><!-- wp:heading {"style":{"spacing":{"margin":{"bottom":"40px"}},"typography":{"textTransform":"uppercase","lineHeight":"1"}},"fontSize":"x-large","fontFamily":"league-gothic"} -->
+<h2 class="has-league-gothic-font-family has-x-large-font-size" style="margin-bottom:40px;line-height:1;text-transform:uppercase">“I always wanted to write, and<br>thanks to Cours, I got it right. My<br>writing is clearer, and I can finally get my message across.”</h2>
 <!-- /wp:heading -->
 
-<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","lineHeight":"1"}},"fontSize":"xx-small","fontFamily":"system"} -->
-<p class="has-system-font-family has-xx-small-font-size" style="font-style:normal;font-weight:700;line-height:1">Christopher Brown</p>
+<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","lineHeight":"1","letterSpacing":"0.02em"}},"fontSize":"xx-small","fontFamily":"system"} -->
+<p class="has-system-font-family has-xx-small-font-size" style="font-style:normal;font-weight:700;letter-spacing:0.02em;line-height:1">Christopher Brown</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"10px"}}},"fontSize":"xx-small","fontFamily":"system"} -->
-<p class="has-system-font-family has-xx-small-font-size" style="padding-top:10px;line-height:1">Founder at BeautifulWriting.com</p>
+<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"10px"}}},"fontSize":"xx-small","fontFamily":"system"} -->
+<p class="has-system-font-family has-xx-small-font-size" style="padding-top:10px;letter-spacing:0.02em;line-height:1">Founder at BeautifulWriting.com</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>


### PR DESCRIPTION
The mailing list and testimonial patterns were not using some of the correct styles, namely the font family. This PR fixes the patterns to better match the design.

## Testing Instructions
- Add the mailing list and testimonial patterns to a page.
- Set the page to use the "Wide Width, No Title" template.
- Ensure the patterns are using the proper styles in both the editor and frontend, especially the font family.

_Before_

![Screenshot 2022-11-11 at 8 08 50 AM](https://user-images.githubusercontent.com/1190420/201347035-5dc7ba13-7a86-4aa7-90b1-5e93209eed9d.jpg)

_After_

![Screenshot 2022-11-11 at 11 30 35 AM](https://user-images.githubusercontent.com/1190420/201386258-d6d6cab0-5699-44f5-a4b6-634551a44069.jpg)