### PR TITLE
Fix links in footer

### DIFF
--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -13,22 +13,22 @@
 <div class="wp-block-column" style="line-height:1.3;flex-basis:81.7%"><!-- wp:columns {"style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"20px"},"blockGap":{"top":"10px","left":"20px"}}},"className":"course-footer-links-vertical-space"} -->
 <div class="wp-block-columns course-footer-links-vertical-space" style="border-left-width:1px;padding-left:20px"><!-- wp:column {"verticalAlignment":"center","width":"128px"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:128px"><!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1"}},"className":"has-gothic-font-family","fontSize":"medium"} -->
-<h3 class="has-gothic-font-family has-medium-font-size" style="line-height:1;text-transform:uppercase"><?php echo esc_html__('social', 'course');?></h3>
+<h3 class="has-gothic-font-family has-medium-font-size" style="line-height:1;text-transform:uppercase"><?php echo esc_html__( 'Social', 'course' );?></h3>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%","layout":{"type":"default"}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"},"fontFamily":"eb-garamond"} -->
 <div class="wp-block-group has-eb-garamond-font-family"><!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><a href="https://www.instagram.com/"><?php echo esc_html__('Instagram', 'course');?></a></p>
+<p class="has-small-font-size"><a href="https://www.instagram.com/"><?php echo esc_html__( 'Instagram', 'course' );?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><a href="https://youtube.com"><?php echo esc_html__('Youtube', 'course');?></a></p>
+<p><a href="https://youtube.com"><?php echo esc_html__( 'YouTube', 'course' );?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><a href="https://spotify.com"><?php echo esc_html__('Spotify', 'course');?></a></p>
+<p><a href="https://spotify.com"><?php echo esc_html__( 'Spotify', 'course' );?></a></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
@@ -37,26 +37,26 @@
 <!-- wp:columns {"style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"20px"},"margin":{"bottom":"20px","top":"20px"},"blockGap":{"top":"10px","left":"20px"}}}} -->
 <div class="wp-block-columns" style="border-left-width:1px;margin-top:20px;margin-bottom:20px;padding-left:20px"><!-- wp:column {"verticalAlignment":"center","width":"128px"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:128px"><!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1"}},"fontSize":"medium"} -->
-<h3 class="has-medium-font-size" style="line-height:1;text-transform:uppercase"><?php echo esc_html__('pages', 'course');?></h3>
+<h3 class="has-medium-font-size" style="line-height:1;text-transform:uppercase"><?php echo esc_html__( 'Pages', 'course' );?></h3>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:group {"style":{"border":{"width":"0px","style":"none"},"spacing":{"blockGap":"20px"}},"layout":{"type":"flex","flexWrap":"wrap"},"fontFamily":"eb-garamond"} -->
 <div class="wp-block-group has-eb-garamond-font-family" style="border-style:none;border-width:0px"><!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><a href="#"><?php echo esc_html__('About', 'course');?></a></p>
+<p class="has-small-font-size"><a href="#"><?php echo esc_html__( 'About', 'course' );?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><a href="#"><?php echo esc_html__('Video', 'course');?></a></p>
+<p><a href="#"><?php echo esc_html__( 'Video', 'course' );?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><a href="#"><?php echo esc_html__('Episodes', 'course');?></a></p>
+<p><a href="#"><?php echo esc_html__( 'Episodes', 'course' );?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><a href="#"><?php echo esc_html__('All Posts', 'course');?></a></p>
+<p><a href="#"><?php echo esc_html__( 'All Posts', 'course' );?></a></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
@@ -66,11 +66,11 @@
 <!-- wp:column {"width":"14.5%"} -->
 <div class="wp-block-column" style="flex-basis:14.5%"><!-- wp:group {"style":{"spacing":{"blockGap":"20px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:paragraph -->
-<p><a href="#"><?php echo esc_html__('Terms', 'course');?></a></p>
+<p><a href="#"><?php echo esc_html__( 'Terms', 'course' );?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><a href="#"><?php echo esc_html__('Privacy', 'course');?></a></p>
+<p><a href="#"><?php echo esc_html__( 'Privacy', 'course' );?></a></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -20,15 +20,15 @@
 <!-- wp:column {"verticalAlignment":"center","width":"50%","layout":{"type":"default"}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"},"fontFamily":"eb-garamond"} -->
 <div class="wp-block-group has-eb-garamond-font-family"><!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><a href="#"><?php echo esc_html__('Instagram', 'course');?></a></p>
+<p class="has-small-font-size"><a href="https://www.instagram.com/"><?php echo esc_html__('Instagram', 'course');?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><a href="#"><?php echo esc_html__('Youtube', 'course');?></a></p>
+<p><a href="https://youtube.com"><?php echo esc_html__('Youtube', 'course');?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><a href="#"><?php echo esc_html__('Spotify', 'course');?></a></p>
+<p><a href="https://spotify.com"><?php echo esc_html__('Spotify', 'course');?></a></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -83,21 +83,22 @@
 
 <p class="has-text-align-center has-background-background-color has-background has-system-font-family has-xx-small-font-size" style="padding-top:80px;padding-bottom:80px;letter-spacing:0.02em">
 <?php
-    /* Translators: WordPress link. */
-    $wordpress_link_underlined = '<a href="' . esc_url( __( 'https://wordpress.org', 'course' ) ) . '" rel="nofollow"><span style="text-decoration: underline;">WordPress</span></a>';
-
-    /* Translators: Sensei link. */
-    $sensei_link = '<a href="' . esc_url( __( 'https://senseilms.com/', 'course' ) ) . '" rel="nofollow">Sensei</a>';
-
-    /* Translators: Name of the theme. */
-    $theme_name_underlined = '<span style="text-decoration: underline;">' . esc_html__('Course Theme', 'course') .'</span>';
-
-    echo sprintf(
-        esc_html__( '%1$s by %2$s, Powered by %3$s.', 'course' ),
-        $theme_name_underlined,
-        $sensei_link,
-        $wordpress_link_underlined
-    );
+	echo sprintf(
+		wp_kses(
+			__( 'Course Theme by <a href="%1$s" rel="nofollow"><span style="text-decoration: underline;">Sensei</span></a>, Powered by <a href="%2$s" rel="nofollow"><span style="text-decoration: underline;">WordPress</span></a>.', 'course' ),
+			[
+				'a' => [
+					'href' => [],
+					'rel' => []
+				],
+				'span' => [
+					'style' => []
+				]
+			]
+		),
+		'https://senseilms.com',
+		'https://wordpress.org'
+	);
 ?>
 </p>
 <!-- /wp:paragraph --></div>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Course
-Theme URI: https://github.com/Automattic/course
+Theme URI: https://senseilms.com
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Course is a flexible and modern theme for anyone wanting to share their knowledge. The theme is built with integration with Sensei LMS and is ideal for Sensei users that are creating or selling courses. Style variations with multiple font and color combinations help you craft the perfect look and feel to show off courses and content. The theme can be used without Sensei too.

--- a/theme.json
+++ b/theme.json
@@ -417,15 +417,6 @@
 					}
 				}
 			},
-			"core/paragraph": {
-				"elements": {
-					"link": {
-						"typography": {
-							"textDecoration": "underline solid var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"core/post-author-name": {
 				"elements": {
 					"link": {


### PR DESCRIPTION
- Remove white underline from _Social_ and _Pages_ links. This was fixed by removing the styles for `core/paragraph`. The links in content are still underlined by the styles for `core/post-content`.
- Add real URLs for YouTube, Instagram and Spotify. Some of Automattic's other themes do this so it seems allowed.
- Fix links in footer text as per #27 (namely, _"Course Theme" should not be a link. Instead, "Sensei" should be a link._).
- Fix escaping of footer text.
  - For reference, see https://developer.wordpress.com/2015/04/23/wordpress-developers-test-your-i18n-internationalization-knowledge/.
  - > Embed HTML in the string when it is necessary to keep the sentence structure intact for translators. Some examples would be href tags or bold/italics around a mid-sentence word.
- Update the Theme URI so that we can link to senseilms.com as per the [theme requirements](https://make.wordpress.org/themes/handbook/review/required/#12-selling-credits-links-and-spam).
- Adhere to WordPress' whitespace coding standards.

## Testing Instructions.
- Ensure the footer links aren't underlined.
- Ensure YouTube, Instagram and Spotify link to the real sites.
- Check that the footer text links to senseilms.com and wordpress.org

## Screenshots
![Screenshot 2022-11-11 at 9 36 21 AM](https://user-images.githubusercontent.com/1190420/201363634-09486ea1-7207-4700-b163-4916c11704cb.jpg)