### PR TITLE
Pair background with foreground colors

### DIFF
--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -7,8 +7,8 @@
  */
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"0px","right":"20px","left":"20px"}},"border":{"top":{"width":"1px"}}},"backgroundColor":"background","textColor":"primary","layout":{"type":"constrained","contentSize":"1000px"}} -->
-<div class="wp-block-group alignfull has-primary-color has-background-background-color has-text-color has-background" style="border-top-width:1px;padding-top:80px;padding-right:20px;padding-bottom:0px;padding-left:20px"><!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"40px","left":"40px"}}}} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"0px","right":"20px","left":"20px"}},"border":{"top":{"width":"1px"}}},"backgroundColor":"background","textColor":"foreground","layout":{"type":"constrained","contentSize":"1000px"}} -->
+<div class="wp-block-group alignfull has-foreground-color has-background-background-color has-text-color has-background" style="border-top-width:1px;padding-top:80px;padding-right:20px;padding-bottom:0px;padding-left:20px"><!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"40px","left":"40px"}}}} -->
 <div class="wp-block-columns"><!-- wp:column {"width":"81.7%","style":{"typography":{"lineHeight":"1.3"}}} -->
 <div class="wp-block-column" style="line-height:1.3;flex-basis:81.7%"><!-- wp:columns {"style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"20px"},"blockGap":{"top":"10px","left":"20px"}}},"className":"course-footer-links-vertical-space"} -->
 <div class="wp-block-columns course-footer-links-vertical-space" style="border-left-width:1px;padding-left:20px"><!-- wp:column {"verticalAlignment":"center","width":"128px"} -->

--- a/patterns/mailing-list.php
+++ b/patterns/mailing-list.php
@@ -10,8 +10,8 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0px","bottom":"100px","right":"20px","left":"20px"}}},"layout":{"type":"constrained","contentSize":"1000px"}} -->
 <div class="wp-block-group alignfull" style="padding-top:0px;padding-right:20px;padding-bottom:100px;padding-left:20px">
-    <!-- wp:group {"style":{"spacing":{"padding":{"left":"38px","top":"20px","bottom":"20px"}},"border":{"top":{"width":"0px","style":"none"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"color":"var:preset|color|primary"}}},"className":"is-style-group-left-border","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-    <div class="wp-block-group is-style-group-left-border" style="border-top-style:none;border-top-width:0px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-color:var(--wp--preset--color--primary);padding-top:20px;padding-bottom:20px;padding-left:38px">
+    <!-- wp:group {"style":{"spacing":{"padding":{"left":"38px","top":"20px","bottom":"20px"}},"border":{"top":{"width":"0px","style":"none"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"color":"var:preset|color|foreground"}}},"className":"is-style-group-left-border","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+    <div class="wp-block-group is-style-group-left-border" style="border-top-style:none;border-top-width:0px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-color:var(--wp--preset--color--foreground);padding-top:20px;padding-bottom:20px;padding-left:38px">
         <!-- wp:heading {"textAlign":"left","style":{"typography":{"textTransform":"uppercase","lineHeight":"1","fontSize":"3rem"},"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"fontFamily":"league-gothic"} -->
         <h2 class="has-text-align-left has-league-gothic-font-family" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;font-size:3rem;line-height:1;text-transform:uppercase"><?php
         echo wp_kses(
@@ -25,8 +25,8 @@
 
         <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right","verticalAlignment":"center"}} -->
         <div class="wp-block-buttons">
-            <!-- wp:button {"backgroundColor":"primary","textColor":"background","style":{"border":{"radius":"8px"}},"fontSize":"x-small"} -->
-            <div class="wp-block-button has-custom-font-size has-x-small-font-size"><a class="wp-block-button__link has-background-color has-primary-background-color has-text-color has-background wp-element-button" style="border-radius:8px"><?php echo esc_html__( 'Join Our Mailing List', 'course' ); ?></a></div>
+            <!-- wp:button {"backgroundColor":"foreground","textColor":"background","style":{"border":{"radius":"8px"}},"fontSize":"x-small"} -->
+            <div class="wp-block-button has-custom-font-size has-x-small-font-size"><a class="wp-block-button__link has-background-color has-foreground-background-color has-text-color has-background wp-element-button" style="border-radius:8px"><?php echo esc_html__( 'Join Our Mailing List', 'course' ); ?></a></div>
             <!-- /wp:button -->
         </div>
         <!-- /wp:buttons -->

--- a/patterns/testimonial.php
+++ b/patterns/testimonial.php
@@ -8,8 +8,8 @@
  */
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"120px","right":"20px","left":"20px"},"blockGap":"0px"}},"backgroundColor":"primary","textColor":"background","layout":{"type":"constrained","contentSize":"1000px"}} -->
-<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background" style="padding-top:80px;padding-right:20px;padding-bottom:120px;padding-left:20px">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"120px","right":"20px","left":"20px"},"blockGap":"0px"}},"backgroundColor":"foreground","textColor":"background","layout":{"type":"constrained","contentSize":"1000px"}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:80px;padding-right:20px;padding-bottom:120px;padding-left:20px">
     <!-- wp:group {"style":{"spacing":{"padding":{"left":"20px","bottom":"0px"}},"border":{"top":{"width":"0px","style":"none"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"color":"var:preset|color|tertiary","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
     <div class="wp-block-group" style="border-top-style:none;border-top-width:0px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-color:var(--wp--preset--color--tertiary);border-left-width:1px;padding-bottom:0px;padding-left:20px">
         <!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1","letterSpacing":"0.01em"},"spacing":{"padding":{"top":"0px"}}},"fontSize":"medium","fontFamily":"league-gothic"} -->

--- a/style.css
+++ b/style.css
@@ -90,13 +90,13 @@ Tags: lms, eLearning, teach, online courses, sensei
 	background-color: var(--wp--preset--color--foreground);
 	color: var(--wp--preset--color--background);
 	padding: 15.5px 32px;
-	border: 1px solid var(--wp--preset--color--primary);
+	border: 1px solid var(--wp--preset--color--foreground);
 }
 
 /* Navbar button color change on hover */
 .wp-block-navigation .wp-block-navigation__responsive-container:not(.is-menu-open) .wp-block-navigation-link.is-style-navigation-link-button a:hover {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--foreground);
 }
 
 /* Set the font size of the menu items in mobile view, except for the button menu item */
@@ -117,7 +117,7 @@ Tags: lms, eLearning, teach, online courses, sensei
 /* Separate hover behavior for navbar button, applicable when in mobile view, as the colors are separate for mobile view */
 .wp-block-navigation .wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation-link.is-style-navigation-link-button a:hover {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--foreground);
 }
 
 /*
@@ -147,15 +147,15 @@ header:not(.is-being-sticky) {
 
 .wp-block-post-comments-form form.comment-form p input:not([type=submit]),
 .wp-block-post-comments-form form.comment-form textarea {
-	border: 1px solid var(--wp--preset--color--primary);
+	border: 1px solid var(--wp--preset--color--foreground);
 	border-radius: 8px;
 	background-color: var(--wp--preset--color--background);
 }
 
 .wp-block-post-comments-form form.comment-form p input[type=submit] {
-	border: 1px solid var(--wp--preset--color--primary);
+	background-color: var(--wp--preset--color--foreground);
+	border: 1px solid var(--wp--preset--color--foreground);
 	border-radius: 8px;
-	background-color: var(--wp--preset--color--primary);
 	text-transform: uppercase;
 	font-family: var(--wp--preset--font-family--league-gothic);
 	font-size: var(--wp--preset--font-size--button-link);
@@ -163,7 +163,7 @@ header:not(.is-being-sticky) {
 }
 
 .wp-block-post-comments-form form.comment-form p input[type=submit]:hover {
-	color:var(--wp--preset--color--primary);
+	color:var(--wp--preset--color--foreground);
 	background-color: transparent;
 }
 
@@ -272,7 +272,7 @@ body .is-layout-flow .wp-block-group {
 .wp-block-search__input {
 	background-color: var(--wp--preset--color--background);
 	padding: 1.063rem;
-	border-color: var(--wp--preset--color--primary);
+	border-color: var(--wp--preset--color--foreground);
 }
 
 /* Add the search icon only when there is no text inside the search button */
@@ -286,7 +286,7 @@ body .is-layout-flow .wp-block-group {
 
 /* Buttons */
 .wp-block-button__link:focus {
-	outline: var(--wp--preset--color--primary) dashed;
+	outline: var(--wp--preset--color--foreground) dashed;
 	outline-offset: 1px;
 }
 
@@ -294,24 +294,24 @@ body .is-layout-flow .wp-block-group {
 * Control the hover stylings of outline block style.
 * Unnecessary once block styles are configurable via theme.json
 */
-.wp-block-buttons .wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):active {
+.wp-block-buttons .wp-block-button.is-style-outline > .wp-block-button__link:not(.has-background):active {
 	background-color: var(--wp--preset--color--secondary);
 	border-color: var(--wp--preset--color--button-border-active);
 	color: var(--wp--preset--color--primary);
 }
 
-.wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):hover {
+.wp-block-button.is-style-outline > .wp-block-button__link:not(.has-background):hover {
 	background-color: var(--wp--preset--color--primary);
 	border-color: var(--wp--preset--color--button-border-hover);
 	color: var(--wp--preset--color--secondary);
 }
 
-.wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):focus {
-	border-color: var(--wp--preset--color--primary);
-	color: var(--wp--preset--color--primary);
+.wp-block-button.is-style-outline > .wp-block-button__link:not(.has-background):focus {
+	border-color: var(--wp--preset--color--foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
-.wp-block-button.is-style-outline>.wp-block-button__link,
+.wp-block-button.is-style-outline > .wp-block-button__link,
 .wp-block-button .wp-block-button__link.is-style-outline {
 	border-width: 1px;
 	padding: 0.5856em 1.5238em;

--- a/templates/search.html
+++ b/templates/search.html
@@ -44,7 +44,7 @@
     <div class="wp-block-column" style="flex-basis:30.6%">
       <!-- wp:group {"className":"sticky-newsletter-sidebar","layout":{"type":"constrained"}} -->
       <div class="wp-block-group sticky-newsletter-sidebar">
-        <!-- wp:social-links {"iconColor":"primary","iconColorValue":"#007062","style":{"spacing":{"blockGap":{"top":"1.33rem","left":"1.33rem"}}},"className":"is-style-logos-only","layout":{"type":"flex","orientation":"horizontal"}} -->
+        <!-- wp:social-links {"iconColor":"primary","iconColorValue":"#00594F","style":{"spacing":{"blockGap":{"top":"1.33rem","left":"1.33rem"}}},"className":"is-style-logos-only","layout":{"type":"flex","orientation":"horizontal"}} -->
         <ul class="wp-block-social-links has-icon-color is-style-logos-only">
 
           <!-- wp:social-link {"url":"#","service":"twitter"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -63,7 +63,7 @@
 
             <!-- wp:group {"className":"sticky-newsletter-sidebar","layout":{"type":"constrained"}} -->
             <div class="wp-block-group sticky-newsletter-sidebar">
-                <!-- wp:social-links {"iconColor":"primary","iconColorValue":"#007062","style":{"spacing":{"blockGap":{"top":"1.33rem","left":"1.33rem"}}},"className":"is-style-logos-only","layout":{"type":"flex","orientation":"horizontal"}} -->
+                <!-- wp:social-links {"iconColor":"primary","iconColorValue":"#00594F","style":{"spacing":{"blockGap":{"top":"1.33rem","left":"1.33rem"}}},"className":"is-style-logos-only","layout":{"type":"flex","orientation":"horizontal"}} -->
                 <ul class="wp-block-social-links has-icon-color is-style-logos-only">
                     
                     <!-- wp:social-link {"url":"#","service":"twitter"} /-->

--- a/theme.json
+++ b/theme.json
@@ -294,7 +294,7 @@
 							"radius": "8px"
 						},
 						"color": {
-							"background": "var(--wp--preset--color--primary)"
+							"background": "var(--wp--preset--color--foreground)"
 						},
 						"typography": {
 							"textTransform": "uppercase",
@@ -620,7 +620,7 @@
 					"letterSpacing": "0.01em"
 				}
 			}
-			
+
 		},
 		"color": {
 			"background": "var(--wp--preset--color--background)",
@@ -635,7 +635,7 @@
 					"width": "1px"
 				},
 				"color": {
-					"background": "var(--wp--preset--color--primary)",
+					"background": "var(--wp--preset--color--foreground)",
 					"text": "var(--wp--preset--color--background)"
 				},
 				"spacing": {
@@ -664,7 +664,7 @@
 				},
 				":focus": {
 					"color": {
-						"background": "var(--wp--preset--color--primary)",
+						"background": "var(--wp--preset--color--foreground)",
 						"text": "var(--wp--preset--color--background)"
 					}
 				},


### PR DESCRIPTION
For buttons, we're pairing `--wp--preset--color--background` with `--wp--preset--color--primary`. It makes more sense to use `--wp--preset--color--foreground` instead of `--wp--preset--color--primary`, as it's more intuitive. I also checked other Automattic themes, and that's what they do as well.

I also updated some of the templates for the same reason. 

Note that `--wp--preset--color--primary` and `--wp--preset--color--foreground` are the same color (`#00594F`), so this change shouldn't impact the UI at all.

## Testing Instructions
- Add the mailing list and testimonial patterns to a page.
- Ensure the page appears the same as before.
- Verify that button colors, all templates and the footer look the same as before.