### PR TITLE
Limit available font sizes and use fluid typography

### DIFF
--- a/patterns/404.php
+++ b/patterns/404.php
@@ -10,8 +10,8 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"20px","left":"20px","bottom":"100px"}}},"layout":{"type":"constrained","contentSize":"1000px","wideSize":"1200px","justifyContent":"left"}} -->
 <div class="wp-block-group" style="padding-right:20px;padding-bottom:100px;padding-left:20px"><!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"0px","left":"0px"}}}} -->
 <div class="wp-block-columns"><!-- wp:column {"width":"70%","style":{"spacing":{"padding":{"right":"20px"}}}} -->
-<div class="wp-block-column" style="padding-right:20px;flex-basis:70%"><!-- wp:heading {"style":{"typography":{"lineHeight":0.9}},"fontSize":"massive"} -->
-<h2 class="has-massive-font-size" style="line-height:0.9">404</h2>
+<div class="wp-block-column" style="padding-right:20px;flex-basis:70%"><!-- wp:heading {"level":1,"style":{"typography":{"lineHeight":0.9}},"fontSize":"xxx-large"} -->
+<h1 class="has-xxx-large-font-size" style="line-height:0.9">404</h1>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -12,15 +12,15 @@
 <div class="wp-block-columns"><!-- wp:column {"width":"81.7%","style":{"typography":{"lineHeight":"1.3"}}} -->
 <div class="wp-block-column" style="line-height:1.3;flex-basis:81.7%"><!-- wp:columns {"style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"20px"},"blockGap":{"top":"10px","left":"20px"}}},"className":"course-footer-links-vertical-space"} -->
 <div class="wp-block-columns course-footer-links-vertical-space" style="border-left-width:1px;padding-left:20px"><!-- wp:column {"verticalAlignment":"center","width":"128px"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:128px"><!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1"}},"className":"has-gothic-font-family","fontSize":"medium"} -->
-<h3 class="has-gothic-font-family has-medium-font-size" style="line-height:1;text-transform:uppercase"><?php echo esc_html__( 'Social', 'course' );?></h3>
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:128px"><!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1"}},"fontSize":"medium","fontFamily":"league-gothic"} -->
+<h3 class="has-league-gothic-font-family has-medium-font-size" style="line-height:1;text-transform:uppercase"><?php echo esc_html__( 'Social', 'course' );?></h3>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%","layout":{"type":"default"}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"},"fontFamily":"eb-garamond"} -->
-<div class="wp-block-group has-eb-garamond-font-family"><!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><a href="https://www.instagram.com/"><?php echo esc_html__( 'Instagram', 'course' );?></a></p>
+<div class="wp-block-group has-eb-garamond-font-family"><!-- wp:paragraph -->
+<p><a href="https://www.instagram.com/"><?php echo esc_html__( 'Instagram', 'course' );?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -36,15 +36,15 @@
 
 <!-- wp:columns {"style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"20px"},"margin":{"bottom":"20px","top":"20px"},"blockGap":{"top":"10px","left":"20px"}}}} -->
 <div class="wp-block-columns" style="border-left-width:1px;margin-top:20px;margin-bottom:20px;padding-left:20px"><!-- wp:column {"verticalAlignment":"center","width":"128px"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:128px"><!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1"}},"fontSize":"medium"} -->
-<h3 class="has-medium-font-size" style="line-height:1;text-transform:uppercase"><?php echo esc_html__( 'Pages', 'course' );?></h3>
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:128px"><!-- wp:heading {"level":3,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1"}},"fontSize":"medium","fontFamily":"league-gothic"} -->
+<h3 class="has-league-gothic-font-family has-medium-font-size" style="line-height:1;text-transform:uppercase"><?php echo esc_html__( 'Pages', 'course' );?></h3>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:group {"style":{"border":{"width":"0px","style":"none"},"spacing":{"blockGap":"20px"}},"layout":{"type":"flex","flexWrap":"wrap"},"fontFamily":"eb-garamond"} -->
-<div class="wp-block-group has-eb-garamond-font-family" style="border-style:none;border-width:0px"><!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><a href="#"><?php echo esc_html__( 'About', 'course' );?></a></p>
+<div class="wp-block-group has-eb-garamond-font-family" style="border-style:none;border-width:0px"><!-- wp:paragraph -->
+<p><a href="#"><?php echo esc_html__( 'About', 'course' );?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -79,9 +79,9 @@
 <!-- wp:site-title {"textAlign":"center","style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"40px"}}},"fontFamily":"sorts-mill-goudy"} /-->
 
 <!-- wp:group {"align":"full","style":{"border":{"top":{"width":"1px"}}},"backgroundColor":"background","className":"course-negative-space-footer","layout":{"type":"constrained","contentSize":""}} -->
-<div class="wp-block-group alignfull course-negative-space-footer has-background-background-color has-background" style="border-top-width:1px"><!-- wp:paragraph {"align":"center","style":{"typography":{"letterSpacing":"0.02em"},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"backgroundColor":"background","fontSize":"xx-small","fontFamily":"system"} -->
+<div class="wp-block-group alignfull course-negative-space-footer has-background-background-color has-background" style="border-top-width:1px"><!-- wp:paragraph {"align":"center","style":{"typography":{"letterSpacing":"0.02em"},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"backgroundColor":"background","fontSize":"x-small","fontFamily":"system"} -->
 
-<p class="has-text-align-center has-background-background-color has-background has-system-font-family has-xx-small-font-size" style="padding-top:80px;padding-bottom:80px;letter-spacing:0.02em">
+<p class="has-text-align-center has-background-background-color has-background has-system-font-family has-x-small-font-size" style="padding-top:80px;padding-bottom:80px;letter-spacing:0.02em">
 <?php
 	echo sprintf(
 		wp_kses(

--- a/patterns/mailing-list.php
+++ b/patterns/mailing-list.php
@@ -12,8 +12,8 @@
 <div class="wp-block-group alignfull" style="padding-top:0px;padding-right:20px;padding-bottom:100px;padding-left:20px">
     <!-- wp:group {"style":{"spacing":{"padding":{"left":"38px","top":"20px","bottom":"20px"}},"border":{"top":{"width":"0px","style":"none"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"color":"var:preset|color|foreground"}}},"className":"is-style-group-left-border","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
     <div class="wp-block-group is-style-group-left-border" style="border-top-style:none;border-top-width:0px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-color:var(--wp--preset--color--foreground);padding-top:20px;padding-bottom:20px;padding-left:38px">
-        <!-- wp:heading {"textAlign":"left","style":{"typography":{"textTransform":"uppercase","lineHeight":"1","fontSize":"3rem"},"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"fontFamily":"league-gothic"} -->
-        <h2 class="has-text-align-left has-league-gothic-font-family" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;font-size:3rem;line-height:1;text-transform:uppercase"><?php
+        <!-- wp:heading {"textAlign":"left","style":{"typography":{"textTransform":"uppercase","lineHeight":"1"},"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"fontSize":"x-large","fontFamily":"league-gothic"} -->
+        <h2 class="has-text-align-left has-league-gothic-font-family has-x-large-font-size" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;line-height:1;text-transform:uppercase"><?php
         echo wp_kses(
                 __( 'Keep track of the latest<br>news and lessons.<br>Every week in your inbox.', 'course' ),
                 [

--- a/patterns/newsletter.php
+++ b/patterns/newsletter.php
@@ -9,8 +9,8 @@
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"1.25rem"}},"layout":{"type":"constrained","justifyContent":"left"}} -->
 <div class="wp-block-group">
-      <!-- wp:heading {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} -->
-      <h2 class="has-medium-font-size" style="text-transform:uppercase"><?php echo esc_html__( 'Newsletter', 'course' ); ?></h2>
+      <!-- wp:heading {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium","fontFamily":"league-gothic"} -->
+      <h2 class="has-league-gothic-font-family has-medium-font-size" style="text-transform:uppercase"><?php echo esc_html__( 'Newsletter', 'course' ); ?></h2>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph -->

--- a/patterns/testimonial.php
+++ b/patterns/testimonial.php
@@ -41,12 +41,12 @@
                 ?></h2>
             <!-- /wp:heading -->
 
-            <!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","lineHeight":"1","letterSpacing":"0.02em"}},"fontSize":"xx-small","fontFamily":"system"} -->
-            <p class="has-system-font-family has-xx-small-font-size" style="font-style:normal;font-weight:700;letter-spacing:0.02em;line-height:1">Christopher Brown</p>
+            <!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","lineHeight":"1","letterSpacing":"0.02em"}},"fontSize":"x-small","fontFamily":"system"} -->
+            <p class="has-system-font-family has-x-small-font-size" style="font-style:normal;font-weight:700;letter-spacing:0.02em;line-height:1">Christopher Brown</p>
             <!-- /wp:paragraph -->
 
-            <!-- wp:paragraph {"style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"10px"}}},"fontSize":"xx-small","fontFamily":"system"} -->
-            <p class="has-system-font-family has-xx-small-font-size" style="padding-top:10px;letter-spacing:0.02em;line-height:1"><?php echo esc_html__( 'Founder at BeautifulWriting.com', 'course' ); ?></p>
+            <!-- wp:paragraph {"style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"10px"}}},"fontSize":"x-small","fontFamily":"system"} -->
+            <p class="has-system-font-family has-x-small-font-size" style="padding-top:10px;letter-spacing:0.02em;line-height:1"><?php echo esc_html__( 'Founder at BeautifulWriting.com', 'course' ); ?></p>
             <!-- /wp:paragraph -->
         </div>
         <!-- /wp:column -->

--- a/style.css
+++ b/style.css
@@ -342,7 +342,7 @@ body .is-layout-constrained > * + * {
 
 .course-newsletter-sign-up {
 	font-family: var(--wp--preset--font-family--system);
-	font-size: var(--wp--preset--font-size--xx-small);
+	font-size: var(--wp--preset--font-size--x-small);
 	letter-spacing: 0.02em;
 	line-height: 100%;
 	text-decoration: underline;

--- a/style.css
+++ b/style.css
@@ -336,8 +336,8 @@ body .is-layout-constrained > * + * {
 }
 
 /* Newsletter */
-body .course-newsletter-gap {
-	height: var(--wp--custom--course-newsletter-gap);
+.course-newsletter-gap {
+	height: clamp(2.5rem, -0.292rem + 9.306vw, 6.688rem);
 }
 
 .course-newsletter-sign-up {

--- a/style.css
+++ b/style.css
@@ -442,3 +442,12 @@ body.page-template-page-wide-width footer .wp-block-group {
 	font-family: var(--wp--preset--font-family--system);
 	text-transform: uppercase;
 }
+
+/*
+ * Style Variations
+ */
+
+/* Workaround for https://github.com/WordPress/gutenberg/issues/35480. */
+.wp-block-social-links .wp-block-social-link .wp-block-social-link-anchor svg {
+	color: var(--wp--preset--color--primary);
+}

--- a/style.css
+++ b/style.css
@@ -82,7 +82,7 @@ Tags: lms, eLearning, teach, online courses, sensei
 
  /* The navigation item that looks like a button in the design has a different front size and the button is rounded */
  .wp-block-navigation .wp-block-navigation__responsive-container .wp-block-navigation-link.is-style-navigation-link-button a {
-	font-size: var(--wp--preset--font-size--button-link);
+	font-size: var(--wp--custom--typography--font-sizes--button);
 	border-radius: 8px;
 }
 
@@ -140,33 +140,14 @@ header:not(.is-being-sticky) {
 	padding: var(--wp--custom--header-padding) 0px;
 }
 
-/* Comments */
-.wp-block-post-comments-form p {
-	font-size: var(--wp--preset--font-size--tiny);
-	line-height: var(--wp--preset--font-size--x-small);
-	text-transform: uppercase;
-}
-
+/*
+ * Comments
+ */
 .wp-block-post-comments-form form.comment-form p input:not([type=submit]),
 .wp-block-post-comments-form form.comment-form textarea {
 	border: 1px solid var(--wp--preset--color--foreground);
 	border-radius: 8px;
 	background-color: var(--wp--preset--color--background);
-}
-
-.wp-block-post-comments-form form.comment-form p input[type=submit] {
-	background-color: var(--wp--preset--color--foreground);
-	border: 1px solid var(--wp--preset--color--foreground);
-	border-radius: 8px;
-	text-transform: uppercase;
-	font-family: var(--wp--preset--font-family--league-gothic);
-	font-size: var(--wp--preset--font-size--button-link);
-	line-height: var(--wp--preset--font-size--button-link);
-}
-
-.wp-block-post-comments-form form.comment-form p input[type=submit]:hover {
-	color:var(--wp--preset--color--foreground);
-	background-color: transparent;
 }
 
 .wp-block-post-comments-form .comment-form-cookies-consent label {
@@ -245,6 +226,7 @@ header:not(.is-being-sticky) {
 .wp-block-comments-query-loop .comment > div > div > .is-vertical {
 	gap: 0;
 }
+
 /*
  * Link styles
  */

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -4,7 +4,7 @@
 <div class="wp-block-group" style="padding-right:20px;padding-bottom:4rem;padding-left:20px">
 	<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","displayLayout":{"type":"flex","columns":3},"layout":{"type":"default"}} -->
 	<main class="wp-block-query">
-		<!-- wp:query-title {"type":"archive","showPrefix":false,"style":{"spacing":{"margin":{"bottom":"5rem"}}},"fontSize":"2-5x-large"} /-->
+		<!-- wp:query-title {"type":"archive","showPrefix":false,"style":{"spacing":{"margin":{"bottom":"5rem"}}}} /-->
 
 		<!-- wp:post-template -->
 		<!-- wp:group {"style":{"spacing":{"blockGap":"0px","padding":{"bottom":"26px"}}},"layout":{"type":"constrained","contentSize":""}} -->

--- a/templates/page.html
+++ b/templates/page.html
@@ -4,7 +4,7 @@
 
   <!-- wp:group {"layout":{"inherit":true,"type":"constrained","contentSize":"666px","justifyContent":"left"}} -->
   <div class="wp-block-group">
-    <!-- wp:post-title {"level":1,"fontSize":"2-5x-large"} /-->
+    <!-- wp:post-title {"level":1} /-->
   </div>
   <!-- /wp:group -->
 
@@ -12,7 +12,7 @@
   <main class="wp-block-group" style="padding-top:2.5rem">
 
     <!-- wp:post-featured-image {"align":"full"} /-->
-    <!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"inherit":true},"fontSize":"small","fontFamily":"eb-garamond"} /-->
+    <!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"inherit":true},"fontFamily":"eb-garamond"} /-->
   </main>
   <!-- /wp:group -->
 

--- a/templates/search.html
+++ b/templates/search.html
@@ -44,7 +44,7 @@
     <div class="wp-block-column" style="flex-basis:30.6%">
       <!-- wp:group {"className":"course-newsletter-sidebar","layout":{"type":"constrained"}} -->
       <div class="wp-block-group course-newsletter-sidebar">
-        <!-- wp:social-links {"iconColor":"primary","iconColorValue":"#00594F","style":{"spacing":{"blockGap":{"top":"1.33rem","left":"1.33rem"}}},"className":"is-style-logos-only","layout":{"type":"flex","orientation":"horizontal"}} -->
+        <!-- wp:social-links {"iconColor":"primary","style":{"spacing":{"blockGap":{"top":"1.33rem","left":"1.33rem"}}},"className":"is-style-logos-only","layout":{"type":"flex","orientation":"horizontal"}} -->
         <ul class="wp-block-social-links has-icon-color is-style-logos-only">
 
           <!-- wp:social-link {"url":"#","service":"twitter"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -60,10 +60,9 @@
 
         <!-- wp:column {"width":"30.7%"} -->
         <div class="wp-block-column" style="flex-basis:30.7%">
-
             <!-- wp:group {"className":"course-newsletter-sidebar","layout":{"type":"constrained"}} -->
             <div class="wp-block-group course-newsletter-sidebar">
-                <!-- wp:social-links {"iconColor":"primary","iconColorValue":"#00594F","style":{"spacing":{"blockGap":{"top":"1.33rem","left":"1.33rem"}}},"className":"is-style-logos-only","layout":{"type":"flex","orientation":"horizontal"}} -->
+                <!-- wp:social-links {"iconColor":"primary","style":{"spacing":{"blockGap":{"top":"1.33rem","left":"1.33rem"}}},"className":"is-style-logos-only","layout":{"type":"flex","orientation":"horizontal"}} -->
                 <ul class="wp-block-social-links has-icon-color is-style-logos-only">
                     
                     <!-- wp:social-link {"url":"#","service":"twitter"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -73,7 +73,7 @@
                 <!-- /wp:social-links -->
             
                 <!-- wp:spacer {"height":"","className":"course-newsletter-gap"} -->
-                <div aria-hidden="true" class="wp-block-spacer course-newsletter-gap"></div>
+                <div style="height:" aria-hidden="true" class="wp-block-spacer course-newsletter-gap"></div>
                 <!-- /wp:spacer -->
             
                 <!-- wp:pattern {"slug":"course/newsletter"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -4,7 +4,7 @@
 <div class="wp-block-group" style="padding-right:20px;padding-left:20px">
 
 <!-- wp:group {"layout":{"type":"constrained","contentSize":"666px","justifyContent":"left"}} -->
-<div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide","style":{"typography":{"lineHeight":0.9,"textTransform":"uppercase"}},"fontSize":"2-5x-large"} /--></div>
+<div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide","style":{"typography":{"lineHeight":0.9,"textTransform":"uppercase"}}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true},"style":{"border":{"bottom":{"width":"1px"},"radius":"0px"}}} -->
@@ -24,16 +24,16 @@
         
         <!-- wp:column {"width":"62.6%","style":{"spacing":{"padding":{"bottom":"40px"}},"typography":{"letterSpacing":"-0.01em"}}} -->
         <div class="wp-block-column" style="flex-basis:62.6%;letter-spacing:-0.01em;padding-bottom:40px">
-            <!-- wp:group {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1","letterSpacing":"-0.02em"},"spacing":{"blockGap":"0.5rem"}},"layout":{"type":"flex","flexWrap":"nowrap"},"fontSize":"xx-small"} -->
-            <div class="wp-block-group has-xx-small-font-size" style="font-style:normal;font-weight:600;letter-spacing:-0.02em;line-height:1">
+            <!-- wp:group {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1","letterSpacing":"-0.02em"},"spacing":{"blockGap":"0.5rem"}},"layout":{"type":"flex","flexWrap":"nowrap"},"fontSize":"x-small"} -->
+            <div class="wp-block-group has-x-small-font-size" style="font-style:normal;font-weight:600;letter-spacing:-0.02em;line-height:1">
             
-                <!-- wp:post-date {"fontSize":"xx-small"} /-->
+                <!-- wp:post-date {"fontSize":"x-small"} /-->
 
                 <!-- wp:heading {"level":6,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontFamily":"system"} -->
                 <h6 class="has-system-font-family" style="font-style:normal;font-weight:600">— by</h6>
                 <!-- /wp:heading -->
             
-                <!-- wp:post-author {"textAlign":"left","showAvatar":false,"showBio":false,"fontSize":"xx-small","fontFamily":"system"} /-->
+                <!-- wp:post-author {"textAlign":"left","showAvatar":false,"showBio":false,"fontSize":"x-small","fontFamily":"system"} /-->
             </div>
             <!-- /wp:group -->
             <!-- wp:post-content {"layout":{"type":"constrained"},"lock":{"move":false,"remove":true}} /-->
@@ -42,13 +42,13 @@
             <div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
             <!-- /wp:spacer -->
 
-            <!-- wp:post-terms {"term":"category","style":{"typography":{"lineHeight":"1"}},"fontSize":"xx-small","fontFamily":"system"} /-->
+            <!-- wp:post-terms {"term":"category","style":{"typography":{"lineHeight":"1"}},"fontSize":"x-small","fontFamily":"system"} /-->
 
             <!-- wp:spacer {"height":"10px"} -->
             <div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
             <!-- /wp:spacer -->
 
-            <!-- wp:post-terms {"term":"post_tag","style":{"typography":{"lineHeight":"1"}},"fontSize":"xx-small","fontFamily":"system"} /-->
+            <!-- wp:post-terms {"term":"post_tag","style":{"typography":{"lineHeight":"1"}},"fontSize":"x-small","fontFamily":"system"} /-->
 
         </div>
         <!-- /wp:column -->

--- a/theme.json
+++ b/theme.json
@@ -68,8 +68,7 @@
 			"replyColumnGap": "2.349rem",
 			"commentGap" : "5rem",
 			"commentGapSmall" : "10px",
-			"commentGapMedium" : "1.25rem",
-			"courseNewsletterGap": "clamp(2.5rem, -0.292rem + 9.306vw, 6.688rem)"
+			"commentGapMedium" : "1.25rem"
 		},
 		"layout": {
 			"contentSize": "1000px",

--- a/theme.json
+++ b/theme.json
@@ -57,6 +57,12 @@
 			]
 		},
 		"custom": {
+			"typography": {
+				"fontSizes": {
+					"normal": "1.5rem",
+					"button": "1.3125rem"
+				}
+			},
 			"navMobileGap": "2.5rem",
 			"headerPadding": "1.25rem",
 			"replyColumnGap": "2.349rem",
@@ -80,6 +86,7 @@
 			]
 		},
 		"typography": {
+			"fluid": true,
 			"fontFamilies": [
 				{
 					"fontFace": [
@@ -152,83 +159,66 @@
 			"fontSizes": [
 				{
 					"name": "Tiny",
-					"size": "0.6875rem",
-					"slug": "tiny"
-				},
-				{
-					"name": "XX small",
-					"size": "1.125rem",
-					"slug": "xx-small"
-				},
-				{
-					"name": "Extra small",
-					"size": "clamp(1.22rem, 2vw + 1.5rem, 1.25rem)",
+					"size": "1rem",
+					"fluid": {
+						"min": "0.875rem",
+						"max": "1.125rem"
+					},
 					"slug": "x-small"
 				},
 				{
 					"name": "Small",
-					"size": "clamp(1.313rem, 1.188rem + 0.416vw, 1.5rem)",
+					"size": "1.125rem",
+					"fluid": {
+						"min": "1rem",
+						"max": "1.25rem"
+					},
 					"slug": "small"
 				},
 				{
 					"name": "Medium",
-					"size": "clamp(1.25rem, 1.33vw + 0.92rem, 1.75rem)",
+					"size": "1.375rem",
+					"fluid": {
+						"min": "1.25rem",
+						"max": "1.75rem"
+					},
 					"slug": "medium"
 				},
 				{
 					"name": "Large",
-					"size": "clamp(1.5rem, 2vw + 1.5rem, 2.25rem)",
+					"size": "1.875rem",
+					"fluid": {
+						"min": "1.5rem",
+						"max": "2.25rem"
+					},
 					"slug": "large"
 				},
 				{
-					"name": "Extra large",
-					"size": "clamp(2rem, 2vw + 1.5rem, 3rem)",
+					"name": "Extra Large",
+					"size": "2.5rem",
+					"fluid": {
+						"min": "2rem",
+						"max": "3rem"
+					},
 					"slug": "x-large"
 				},
 				{
-					"name": "XX Large",
-					"size": "clamp(3rem, 5.03vw + 0.24rem, 4rem)",
+					"name": "Huge",
+					"size": "4.5rem",
+					"fluid": {
+						"min": "3rem",
+						"max": "6rem"
+					},
 					"slug": "xx-large"
 				},
 				{
-					"name": "2.5X Large",
-					"size": "clamp(4rem, calc(4rem + ((1vw - 0.3rem) * 2.6389)), 5.1875rem)",
-					"slug": "2-5x-large"
-				},
-				{
-					"name": "3X Large",
-					"size": "clamp(3rem, 5vw + 1.5rem, 6.029rem)",
-					"slug": "3x-large"
-				},
-				{
-					"name": "3.5X Large",
-					"size": "clamp(64px, calc(4rem + ((1vw - 4.8px) * 6.3889)), 110px);",
-					"slug": "3-2x-large"
-				},
-				{
-					"name": "4X Large",
-					"size": "clamp(4rem, 12vw + 1rem, 8.5rem)",
-					"slug": "4x-large"
-				},
-				{
-					"name": "5X Large",
-					"size": "clamp(83px, calc(5.1875rem + ((1vw - 4.8px) * 25.1389)), 264px)",
-					"slug": "5x-large"
-				},
-				{
-					"name": "Massive",
-					"size": "clamp(16.125rem, 8.125rem + 26.667vw, 28.125rem)",
-					"slug": "massive"
-				},
-				{
-					"name": "Navbar Medium",
-					"size": "1.5rem",
-					"slug": "nav-medium"
-				},
-				{
-					"name": "Button Link",
-					"size": "1.3125rem",
-					"slug": "button-link"
+					"name": "Gigantic",
+					"size": "16.125rem",
+					"fluid": {
+						"min": "16.125rem",
+						"max": "28.125rem"
+					},
+					"slug": "xxx-large"
 				}
 			]
 		}
@@ -263,10 +253,9 @@
 			"core/comments": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--system)",
-					"fontSize": "var(--wp--preset--font-size--xx-small)",
-					"lineHeight": "var(--wp--preset--font-size--xx-small)",
-					"fontWeight": "400",
-					"letterSpacing": "2%"
+					"fontSize": "var(--wp--preset--font-size--x-small)",
+					"lineHeight": "var(--wp--preset--font-size--x-small)",
+					"fontWeight": "400"
 				},
 				"elements": {
 					"link": {
@@ -281,12 +270,15 @@
 			},
 			"core/post-comments-form": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system)"
+					"fontFamily": "var(--wp--preset--font-family--system)",
+					"fontSize": "11px",
+					"lineHeight": "145%",
+					"textTransform": "uppercase"
 				},
 				"elements": {
 					"heading": {
 						"typography": {
-							"fontSize": "var(--wp--preset--font-size--nav-medium)"
+							"fontSize": "var(--wp--custom--typography--font-sizes--normal)"
 						}
 					},
 					"button": {
@@ -298,10 +290,9 @@
 						},
 						"typography": {
 							"textTransform": "uppercase",
-							"fontWeight": "400",
 							"fontFamily": "var(--wp--preset--font-family--league-gothic)",
-							"fontSize": "var(--wp--preset--font-size--button-link)",
-							"lineHeight": "var(--wp--preset--font-size--button-link)"
+							"fontSize": "var(--wp--custom--typography--font-sizes--button)",
+							"lineHeight": "100%"
 						}
 					}
 				}
@@ -315,8 +306,8 @@
 						"typography": {
 							"textDecoration": "none",
 							"fontFamily": "var(--wp--preset--font-family--system)",
-							"fontSize": "var(--wp--preset--font-size--xx-small)",
-							"lineHeight": "var(--wp--preset--font-size--xx-small)"
+							"fontSize": "var(--wp--preset--font-size--x-small)",
+							"lineHeight": "var(--wp--preset--font-size--x-small)"
 						}
 					}
 				}
@@ -330,7 +321,7 @@
 			},
 			"core/comment-content": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--custom--typography--font-sizes--normal)",
 					"lineHeight": "160%",
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)"
 				},
@@ -354,8 +345,8 @@
 						"typography": {
 							"textDecoration": "none",
 							"fontFamily": "var(--wp--preset--font-family--system)",
-							"fontSize": "var(--wp--preset--font-size--xx-small)",
-							"lineHeight": "var(--wp--preset--font-size--xx-small)"
+							"fontSize": "var(--wp--preset--font-size--x-small)",
+							"lineHeight": "100%"
 						}
 					}
 				}
@@ -366,8 +357,8 @@
 						"typography": {
 							"textDecoration": "underline solid 1px",
 							"fontFamily": "var(--wp--preset--font-family--system)",
-							"fontSize": "var(--wp--preset--font-size--xx-small)",
-							"lineHeight": "var(--wp--preset--font-size--xx-small)"
+							"fontSize": "var(--wp--preset--font-size--x-small)",
+							"lineHeight": "100%"
 						}
 					}
 				}
@@ -378,8 +369,8 @@
 						"typography": {
 							"textDecoration": "underline solid 1px",
 							"fontFamily": "var(--wp--preset--font-family--system)",
-							"fontSize": "var(--wp--preset--font-size--xx-small)",
-							"lineHeight": "var(--wp--preset--font-size--xx-small)"
+							"fontSize": "var(--wp--preset--font-size--x-small)",
+							"lineHeight": "var(--wp--preset--font-size--x-small)"
 						}
 					}
 				}
@@ -406,7 +397,6 @@
 							"fontWeight": "400",
 							"textDecoration": "none",
 							"fontFamily": "var(--wp--preset--font-family--league-gothic)",
-							"fontSize": "var(--wp--preset--font-size--nav-medium)",
 							"lineHeight": "1.5rem"
 						},
 						":hover": {
@@ -445,8 +435,6 @@
 					},
 					"heading": {
 						"typography": {
-							"fontFamily": "var(--wp--preset--font-family--system)",
-							"fontWeight": "590",
 							"letterSpacing": "-0.01em"
 						},
 						"spacing": {
@@ -463,13 +451,14 @@
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--system)",
-					"fontSize": "var(--wp--preset--font-size--xx-small)"
+					"fontSize": "var(--wp--preset--font-size--x-small)",
+					"letterSpacing": "0.02em"
 				},
 				"elements": {
 					"link": {
 						"typography": {
 							"textDecoration": "none",
-							"fontSize": "var(--wp--preset--font-size--xx-small)"
+							"fontSize": "var(--wp--preset--font-size--x-small)"
 						},
 						":hover": {
 							"typography": {
@@ -505,6 +494,7 @@
 				"elements": {
 					"link": {
 						"typography": {
+							"fontFamily": "var(--wp--preset--font-family--league-gothic)",
 							"textDecoration": "none"
 						},
 						":hover": {
@@ -535,7 +525,7 @@
 						"cite": {
 							"typography": {
 								"fontStyle": "normal",
-								"fontSize": "var(--wp--preset--font-size--xx-small)",
+								"fontSize": "var(--wp--preset--font-size--x-small)",
 								"fontFamily": "var(--wp--preset--font-family--system)",
 								"textTransform": "none"
 							}
@@ -552,7 +542,7 @@
 					"cite": {
 						"typography": {
 							"fontStyle": "normal",
-							"fontSize": "var(--wp--preset--font-size--xx-small)",
+							"fontSize": "var(--wp--preset--font-size--x-small)",
 							"fontFamily": "var(--wp--preset--font-family--system)"
 						}
 					}
@@ -569,7 +559,7 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--xx-small)",
+					"fontSize": "var(--wp--preset--font-size--x-small)",
 					"lineHeight": "1.6"
 				}
 			},
@@ -590,6 +580,7 @@
 			},
 			"core/site-title": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--league-gothic)",
 					"textTransform": "uppercase"
 				},
 				"elements": {
@@ -648,7 +639,6 @@
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--league-gothic)",
-					"fontSize": "var(--wp--preset--font-size--button-link)",
 					"fontWeight": "400",
 					"letterSpacing": "0.05em",
 					"textTransform": "uppercase"
@@ -680,23 +670,22 @@
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--league-gothic)",
+					"fontFamily": "var(--wp--preset--font-family--system)",
 					"fontWeight": "400",
-					"lineHeight": "1.125"
+					"lineHeight": "100%"
 				}
 			},
 			"h1": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--3-x-large)",
+					"fontFamily": "var(--wp--preset--font-family--league-gothic)",
+					"fontSize": "var(--wp--preset--font-size--xx-large)",
 					"fontWeight": "400",
-					"textTransform": "uppercase",
-					"lineHeight": "96%"
+					"textTransform": "uppercase"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"lineHeight": "96%"
+					"fontSize": "var(--wp--preset--font-size--x-large)"
 				}
 			},
 			"h3": {
@@ -706,17 +695,17 @@
 			},
 			"h4": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--x-small)"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--xx-small)"
+					"fontSize": "var(--wp--preset--font-size--x-small)"
 				}
 			},
 			"link": {
@@ -751,7 +740,7 @@
 		},
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
-			"fontSize": "var(--wp--preset--font-size--small)",
+			"fontSize": "var(--wp--custom--typography--font-sizes--normal)",
 			"lineHeight": "1.838rem"
 		}
 	},

--- a/theme.json
+++ b/theme.json
@@ -639,6 +639,7 @@
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--league-gothic)",
+					"fontSize": "var(--wp--custom--typography--font-sizes--button)",
 					"fontWeight": "400",
 					"letterSpacing": "0.05em",
 					"textTransform": "uppercase"


### PR DESCRIPTION
This PR reduces the number of font sizes that we surface in the _Size_ dropdown. Some weren't being used, and others have been reorganized. Font sizes are now fluid! 🥳 

I've also removed the hardcoded color value for the social icons and used CSS instead. This is in preparation for adding variations.

## Testing Instructions
- Create a page with a paragraph block.
- Open the font size dropdown and ensure only the following sizes appear: _Default_, _Tiny_, _Small_, _Medium_, _Large_, _Extra Large_, _Huge_, _Gigantic_, _Custom_. These names were selected based on what I saw in some of A8C's themes.
- Click through all pages (post, page, comments, search, 404, patterns etc.) and ensure the text looks good. I'd say it's not necessary to check that each element's font size matches the design at this point, as this change is just too pervasive.
- Ensure the social icons are the correct color (`#00594F`).