### PR TITLE
Fix header appearing behind some elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -126,7 +126,7 @@ Tags: lms, eLearning, teach, online courses, sensei
 * -1px is added instead of zero to easily determine when it's being sticky using js.
 * z index needed to be added, featured tag comes on top otherwise.
 */
-header {
+header.wp-block-template-part {
 	position: sticky;
 	top: -1px;;
 	z-index: 1111;
@@ -135,7 +135,7 @@ header {
 }
 
 /* No background color needed as per design when the navbar is being sticky on top */
-header:not(.is-being-sticky) {
+header.wp-block-template-part:not(.is-being-sticky) {
 	background-color: transparent;
 	padding: var(--wp--custom--header-padding) 0px;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/course/issues/105

## Changes proposed in this request

- Module titles in course outline were stacking on top of header when scrolling. Fixed that issue.

## Testing instructions

- Create a course
- Add a few modules so that some of them gets scrolled out of screen space when you scroll to the bottom
- Make sure no elements hide the header or goes on top of it

## Screenshots

Before
![Screen Shot 2022-11-22 at 4 47 42 PM](https://user-images.githubusercontent.com/6820724/203309484-3945c87e-ec00-4ecb-9fa3-fa2e875d8980.png)

After
![Screen Shot 2022-11-22 at 6 04 00 PM](https://user-images.githubusercontent.com/6820724/203309505-8e07b207-5218-4a58-bade-b2307f090fe9.png)

