### PR TITLE
Variation site title in the header should use heading font, not League Gothic

### DIFF
--- a/styles/blue.json
+++ b/styles/blue.json
@@ -114,23 +114,6 @@
 					]
 				},
 				{
-					"fontFamily": "\"League Gothic\", serif",
-					"name": "League Gothic",
-					"slug": "league-gothic",
-					"fontFace": [
-						{
-							"fontDisplay": "block",
-							"fontFamily": "League Gothic",
-							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"fontWeight": "200 800",
-							"src": [
-								"file:./assets/fonts/leaguegothic-regular-variablefont_wdth-webfont.woff2"
-							]
-						}
-					]
-				},
-				{
 					"fontFamily": "Sorts Mill Goudy",
 					"name": "Sorts Mill Goudy",
 					"slug": "sorts-mill-goudy",
@@ -258,11 +241,6 @@
 			"core/post-content": {
 				"typography": {
 					"lineHeight": "132%"
-				}
-			},
-			"core/site-title": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--league-gothic)"
 				}
 			}
 		},

--- a/styles/blue.json
+++ b/styles/blue.json
@@ -230,7 +230,6 @@
 				"elements": {
 					"link": {
 						"typography": {
-							"fontFamily": "var(--wp--preset--font-family--body)",
 							"letterSpacing": "-0.01em",
 							"lineHeight": "100%",
 							"textTransform": "uppercase"

--- a/styles/dark.json
+++ b/styles/dark.json
@@ -99,23 +99,6 @@
 					]
 				},
 				{
-					"fontFamily": "\"League Gothic\", serif",
-					"name": "League Gothic",
-					"slug": "league-gothic",
-					"fontFace": [
-						{
-							"fontDisplay": "block",
-							"fontFamily": "League Gothic",
-							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"fontWeight": "200 800",
-							"src": [
-								"file:./assets/fonts/leaguegothic-regular-variablefont_wdth-webfont.woff2"
-							]
-						}
-					]
-				},
-				{
 					"fontFamily": "Sorts Mill Goudy",
 					"name": "Sorts Mill Goudy",
 					"slug": "sorts-mill-goudy",
@@ -217,11 +200,6 @@
 			"core/post-content": {
 				"typography": {
 					"lineHeight": "132%"
-				}
-			},
-			"core/site-title": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--league-gothic)"
 				}
 			}
 		},

--- a/styles/gold.json
+++ b/styles/gold.json
@@ -109,23 +109,6 @@
 					]
 				},
 				{
-					"fontFamily": "\"League Gothic\", serif",
-					"name": "League Gothic",
-					"slug": "league-gothic",
-					"fontFace": [
-						{
-							"fontDisplay": "block",
-							"fontFamily": "League Gothic",
-							"fontStretch": "normal",
-							"fontStyle": "normal",
-							"fontWeight": "200 800",
-							"src": [
-								"file:./assets/fonts/leaguegothic-regular-variablefont_wdth-webfont.woff2"
-							]
-						}
-					]
-				},
-				{
 					"fontFamily": "Sorts Mill Goudy",
 					"name": "Sorts Mill Goudy",
 					"slug": "sorts-mill-goudy",
@@ -219,11 +202,6 @@
 							"fontSize": "var(--wp--preset--font-size--small)"
 						}
 					}
-				}
-			},
-			"core/site-title": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--league-gothic)"
 				}
 			}
 		},


### PR DESCRIPTION
Update the site title in the header of the variations to use the heading font instead of League Gothic. The fonts are as follows:

- Blue variation: Lora
- Dark variation: Syne
- Gold variation: Montserrat

### Testing Instructions
- Check each of the variations to ensure that they are using the correct font for the site title that appears in the header.
- Check the DevTools to ensure that the League Gothic font isn't being loaded for any variation (it's only used in Default).

### Screenshots

_Blue Variation_

![Site Title - Blue](https://user-images.githubusercontent.com/1190420/204375351-0cd18053-4966-4bab-87b7-39cd5c8dc1d4.jpg)

_Dark Variation_

![Site Title - Dark](https://user-images.githubusercontent.com/1190420/204375371-fb92ec4f-7930-46b5-8ceb-01cd106df110.jpg)

_Gold Variation

![Site Title - Gold](https://user-images.githubusercontent.com/1190420/204375395-715161cf-e759-43e8-b30b-1599eceb7461.jpg)