### PR TITLE
Fix course patterns layout

### DIFF
--- a/patterns/404.php
+++ b/patterns/404.php
@@ -7,8 +7,8 @@
 
 ?>
 
-<!-- wp:group {"style":{"spacing":{"padding":{"right":"20px","left":"20px","bottom":"100px"}}},"layout":{"type":"constrained","contentSize":"1000px","wideSize":"1200px","justifyContent":"left"}} -->
-<div class="wp-block-group" style="padding-right:20px;padding-bottom:100px;padding-left:20px"><!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"0px","left":"0px"}}}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"100px"}}},"layout":{"type":"constrained","contentSize":"1000px","wideSize":"1200px","justifyContent":"left"}} -->
+<div class="wp-block-group" style="padding-bottom:100px;"><!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"0px","left":"0px"}}}} -->
 <div class="wp-block-columns"><!-- wp:column {"width":"70%","style":{"spacing":{"padding":{"right":"20px"}}}} -->
 <div class="wp-block-column" style="padding-right:20px;flex-basis:70%"><!-- wp:heading {"level":1,"style":{"typography":{"lineHeight":0.9}},"fontSize":"xxx-large"} -->
 <h1 class="has-xxx-large-font-size" style="line-height:0.9">404</h1>
@@ -17,8 +17,8 @@
 
 <!-- wp:column {"width":"30%"} -->
 <div class="wp-block-column" style="flex-basis:30%"><!-- wp:group {"style":{"spacing":{"padding":{"top":"40px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:40px"><!-- wp:paragraph {"style":{"spacing":{"padding":{"bottom":"40px"}},"typography":{"lineHeight":"1.3"}}} -->
-<p style="padding-bottom:40px"><?php echo esc_html__( 'This page could not be found.', 'course' ); ?><br><?php echo esc_html__( 'Maybe you should try a search.', 'course' ); ?></p>
+<div class="wp-block-group" style="padding-top:40px"><!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.3"}}} -->
+<p style="line-height:1.3"><?php echo esc_html__( 'This page could not be found.', 'course' ); ?><br><?php echo esc_html__( 'Maybe you should try a search.', 'course' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:search {"label":"","showLabel":false,"placeholder":"<?php echo esc_html__( 'Search...', 'course' ); ?>","width":100,"widthUnit":"%","buttonText":"Search","buttonUseIcon":true,"style":{"border":{"radius":"4px","width":"1px"}},"borderColor":"primary","textColor":"tertiary","className":"course-search-sidebar"} /--></div>

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -76,7 +76,7 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:site-title {"textAlign":"center","style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"40px"}}},"fontFamily":"sorts-mill-goudy"} /-->
+<!-- wp:site-title {"textAlign":"center","style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"20px"}}},"fontFamily":"sorts-mill-goudy"} /-->
 
 <!-- wp:group {"align":"full","style":{"border":{"top":{"width":"1px"}}},"backgroundColor":"background","className":"course-negative-space-footer","layout":{"type":"constrained","contentSize":""}} -->
 <div class="wp-block-group alignfull course-negative-space-footer has-background-background-color has-background" style="border-top-width:1px"><!-- wp:paragraph {"align":"center","style":{"typography":{"letterSpacing":"0.02em"},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"backgroundColor":"background","fontSize":"x-small"} -->

--- a/style.css
+++ b/style.css
@@ -235,16 +235,6 @@ a {
 	text-underline-offset: .15em
 }
 
-/* Reduce the default vertical distance between elements when inside a layout flow */
-body .is-layout-flow > * + * {
-	margin-block-start: 0px;
-}
-
-/* Remove the default vertical distance between elements when inside a layout flow */
-body .is-layout-flow .wp-block-group {
-	margin-block-end: 0px;
-}
-
 /*
  * Search styles
  */
@@ -310,16 +300,6 @@ body .is-layout-flow .wp-block-group {
 .wp-block-post-author__avatar img {
 	border: 1px solid var(--wp--preset--color--tertiary);
 	border-radius: 4px;
-}
-
-/* Remove default spacings so that we can use our own spacings */
-body .is-layout-flow > * {
-	margin-block-end: 0;
-	margin-bottom: 0;
-}
-
-body .is-layout-constrained > * + * {
-	margin-block-start: 0px;
 }
 
 /* Design for search box in 404 page template sidebar */

--- a/style.css
+++ b/style.css
@@ -268,7 +268,7 @@ body .is-layout-flow .wp-block-group {
 * Control the hover stylings of outline block style.
 * Unnecessary once block styles are configurable via theme.json
 */
-.wp-block-buttons .wp-block-button.is-style-outline > .wp-block-button__link:not(.has-background):active {
+.wp-block-button.is-style-outline > .wp-block-button__link:not(.has-background):active {
 	background-color: var(--wp--preset--color--secondary);
 	border-color: var(--wp--preset--color--button-border-active);
 	color: var(--wp--preset--color--primary);
@@ -287,8 +287,12 @@ body .is-layout-flow .wp-block-group {
 
 .wp-block-button.is-style-outline > .wp-block-button__link,
 .wp-block-button .wp-block-button__link.is-style-outline {
+	background-color: transparent;
+	border-color: currentcolor;
 	border-width: 1px;
+	color: currentcolor;
 	padding: 0.5856em 1.5238em;
+	text-decoration: none;
 }
 
 /*

--- a/style.css
+++ b/style.css
@@ -321,7 +321,7 @@ a {
 
 /* Newsletter */
 .course-newsletter-gap {
-	height: clamp(2.5rem, -0.292rem + 9.306vw, 6.688rem);
+	height: clamp(0rem, -3.975rem + 8.134vw, calc(114px - var(--wp--style--block-gap) * 2));
 }
 
 .course-newsletter-sign-up {

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"},"style":{"spacing":{"blockGap":"var:preset|spacing|50","margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|60"}}}} -->
-<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--60)">
+<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"},"style":{"spacing":{"blockGap":"var:preset|spacing|50","margin":{"left":"20px","right":"20px","bottom":"80px"}}}} -->
+<main class="wp-block-group" style="margin-right:20px;margin-bottom:80px;margin-left:20px">
 	
 	<!-- wp:pattern {"slug":"course/404"} /-->
 

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"left":"20px","right":"20px","bottom":"4rem"}}},"layout":{"type":"constrained","contentSize":"1000px","wideSize":"1200px"}} -->
-<div class="wp-block-group" style="padding-right:20px;padding-bottom:4rem;padding-left:20px">
+<!-- wp:group {"style":{"spacing":{"margin":{"left":"20px","right":"20px","bottom":"80px"}}},"layout":{"type":"constrained","contentSize":"1000px","wideSize":"1200px"}} -->
+<div class="wp-block-group" style="margin-right:20px;margin-bottom:80px;margin-left:20px">
 	<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","displayLayout":{"type":"flex","columns":3},"layout":{"type":"default"}} -->
 	<main class="wp-block-query">
 		<!-- wp:query-title {"type":"archive","showPrefix":false,"style":{"spacing":{"margin":{"bottom":"5rem"}}}} /-->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,32 +1,35 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
-<main class="wp-block-query">
-	<!-- wp:post-template -->
-	<!-- wp:group {"style":{"spacing":{"blockGap":"20px"}}} -->
-	<div class="wp-block-group">
-		<!-- wp:post-title {"isLink":true} /-->
-		<!-- wp:post-featured-image {"isLink":true} /-->
-		<!-- wp:post-excerpt /-->
-		<!-- wp:template-part {"slug":"post-meta"} /-->
-		<!-- wp:spacer {"height":40} -->
-		<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
-	</div>
-	<!-- /wp:group -->
-	<!-- /wp:post-template -->
-    <!-- wp:group {"layout":{"inherit":false,"type":"constrained"}} -->
-    <div class="wp-block-group">
-      <!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
-    
-      <!-- wp:query-pagination-numbers /-->
-    
-      <!-- wp:query-pagination-next {"label":"next"} /-->
-      <!-- /wp:query-pagination -->
-    </div>
-    <!-- /wp:group -->
+<!-- wp:group {"style":{"spacing":{"margin":{"left":"20px","right":"20px","bottom":"80px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-right:20px;margin-bottom:80px;margin-left:20px">
+	<!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
+	<main class="wp-block-query">
+		<!-- wp:post-template -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"20px"}}} -->
+		<div class="wp-block-group">
+			<!-- wp:post-title {"isLink":true} /-->
+			<!-- wp:post-featured-image {"isLink":true} /-->
+			<!-- wp:post-excerpt /-->
+			<!-- wp:template-part {"slug":"post-meta"} /-->
+			<!-- wp:spacer {"height":20} -->
+			<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+		</div>
+		<!-- /wp:group -->
+		<!-- /wp:post-template -->
+		<!-- wp:group {"layout":{"inherit":false,"type":"constrained"}} -->
+		<div class="wp-block-group">
+			<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+
+			<!-- wp:query-pagination-numbers /-->
+
+			<!-- wp:query-pagination-next {"label":"next"} /-->
+			<!-- /wp:query-pagination -->
+		</div>
+		<!-- /wp:group -->
 	</main>
 	<!-- /wp:query -->
-	
-	<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
-	
+</div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/page-wide-width.html
+++ b/templates/page-wide-width.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true},"style":{"spacing":{"blockGap":"0px"}}} -->
-<main class="wp-block-group">
+<!-- wp:group {"style":{"spacing":{"margin":{"left":"20px","right":"20px","bottom":"80px"}}},"tagName":"main","lock":{"move":false,"remove":true}} -->
+<main class="wp-block-group" style="margin-right:20px;margin-bottom:80px;margin-left:20px">
 <!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 </main>
 <!-- /wp:group -->

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","theme":"course","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"margin":{"left":"20px","right":"20px"}}},"layout":{"type":"constrained","contentSize":"1000px"}} -->
-<div class="wp-block-group" style="margin-right:20px;margin-left:20px">
+<!-- wp:group {"style":{"spacing":{"margin":{"left":"20px","right":"20px","bottom":"80px"}}},"layout":{"type":"constrained","contentSize":"1000px"}} -->
+<div class="wp-block-group" style="margin-right:20px;margin-bottom:80px;margin-left:20px">
 
   <!-- wp:group {"layout":{"inherit":true,"type":"constrained","contentSize":"666px","justifyContent":"left"}} -->
   <div class="wp-block-group">
@@ -17,10 +17,6 @@
   </main>
   <!-- /wp:group -->
 
-  <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
-  <div class="wp-block-group">
-  </div>
-  <!-- /wp:group -->
 </div>
 <!-- /wp:group -->
 

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","theme":"course","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"right":"20px","left":"20px"}}},"layout":{"type":"constrained","contentSize":"1000px","wideSize":"1200px"}} -->
-<div class="wp-block-group" style="padding-right:20px;padding-left:20px">
+<!-- wp:group {"style":{"spacing":{"margin":{"right":"20px","left":"20px","bottom":"80px"}}},"layout":{"type":"constrained","contentSize":"1000px","wideSize":"1200px"}} -->
+<div class="wp-block-group" style="margin-right:20px;margin-bottom:80px;margin-left:20px">
   <!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"5rem","left":"5rem"}}}} -->
   <div class="wp-block-columns">
     <!-- wp:column {"width":"61.4%","style":{"spacing":{"blockGap":"0rem"}},"layout":{"type":"constrained"}} -->
@@ -15,8 +15,8 @@
       <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null},"displayLayout":{"type":"list"},"layout":{"type":"constrained"}} -->
       <div class="wp-block-query">
         <!-- wp:post-template -->
-        <!-- wp:group {"style":{"spacing":{"blockGap":"20px","padding":{"bottom":"58px"}}}} -->
-        <div class="wp-block-group" style="padding-bottom:58px">
+        <!-- wp:group {"style":{"spacing":{"blockGap":"20px","padding":{"bottom":"56px"}}}} -->
+        <div class="wp-block-group" style="padding-bottom:56px">
           <!-- wp:post-date {"style":{"typography":{"lineHeight":"1"}}} /-->
 
           <!-- wp:post-title {"isLink":true,"style":{"typography":{"lineHeight":"1"}}} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"margin":{"left":"20px","right":"20px"}}},"layout":{"type":"constrained","contentSize":"1000px","wideSize":"1000px"}} -->
-<div class="wp-block-group" style="margin-right:20px;margin-left:20px">
+<!-- wp:group {"style":{"spacing":{"margin":{"left":"20px","right":"20px","bottom":"80px"}}},"layout":{"type":"constrained","contentSize":"1000px","wideSize":"1000px"}} -->
+<div class="wp-block-group" style="margin-right:20px;margin-bottom:80px;margin-left:20px">
 
 <!-- wp:group {"layout":{"type":"constrained","contentSize":"666px","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide","style":{"typography":{"textTransform":"uppercase"}}} /--></div>
@@ -11,8 +11,8 @@
 <main class="wp-block-group" style="border-radius:0px;border-bottom-width:1px;margin-top:2.5rem">
     <!-- wp:post-featured-image /-->
     
-    <!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"0px","left":"0px"},"margin":{"top":"40px","bottom":"40px"}}}} -->
-    <div class="wp-block-columns" style="margin-top:40px;margin-bottom:40px">
+    <!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"0px","left":"0px"},"margin":{"bottom":"40px"}}}} -->
+    <div class="wp-block-columns" style="margin-bottom:40px">
         
         <!-- wp:column {"width":"66.66%","style":{"spacing":{"margin":{"bottom":"40px","right":"70px"}},"typography":{"letterSpacing":"-0.01em"}}} -->
         <div class="wp-block-column" style="flex-basis:66.66%;letter-spacing:-0.01em;margin-right:70px;margin-bottom:40px">
@@ -30,15 +30,7 @@
             <!-- /wp:group -->
             <!-- wp:post-content {"layout":{"type":"constrained"},"lock":{"move":false,"remove":true}} /-->
 
-            <!-- wp:spacer {"height":"20px"} -->
-            <div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
-            <!-- /wp:spacer -->
-
             <!-- wp:post-terms {"term":"category","style":{"typography":{"lineHeight":"1"}},"fontSize":"x-small","fontFamily":"system"} /-->
-
-            <!-- wp:spacer {"height":"10px"} -->
-            <div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
-            <!-- /wp:spacer -->
 
             <!-- wp:post-terms {"term":"post_tag","style":{"typography":{"lineHeight":"1"}},"fontSize":"x-small","fontFamily":"system"} /-->
 

--- a/theme.json
+++ b/theme.json
@@ -465,11 +465,7 @@
 			},
 			"core/post-content": {
 				"spacing": {
-					"blockGap": "20px",
-					"padding": {
-						"top": "1.25rem",
-						"bottom": "1.25rem"
-					}
+					"blockGap": "20px"
 				},
 				"typography": {
 					"lineHeight": "clamp(1.838rem, 1.763rem + 0.249vw, 1.95rem)",


### PR DESCRIPTION
The existing course patterns did not look good on our theme. The blocks were all squished together. This was due to us resetting some of the margins in the CSS, which was essentially nullifying the `blockGap` setting in `theme.json`. I don't think we should be overwriting that rule, especially now that we know how it can affect other things (like course patterns).

This PR:
- Fixes the styling of the _Contact Teacher_ button.
- Removes the margin resets for the layout container classes.
- Adjusts the templates to compensate for removing the margin resets, since the `blockGap` setting is now applying `40px` of margin.
- Made the spacing consistent between the header and page title, and between the end of the content and the start of the footer across all pages. Although this may deviate from the designs, it's a call I decided to make to prioritize consistency over building exactly to spec (especially given we're not sure of the intentionality behind some of the design elements).

### Testing Steps
- Create a new course that uses the _Long Sales Page_ pattern.
- Switch template to use _Wide Width, No Title_ pattern (not needed after [templates issue ](https://github.com/Automattic/course/issues/125)is fixed).
- Ensure the page looks good in the editor and on the frontend.
- Check that the _Contact Teacher_ button is styled correctly.
- Repeat for the _Life Coach_ and _Video Hero_ pattern.
- Check that the other templates still look good. Pay particular attention to the sidebar of posts.

_Long Sales Page - Before_

![screencapture-senseitheme-local-course-long-sales-page-2022-11-30-10_46_46](https://user-images.githubusercontent.com/1190420/204843788-5e41e5ac-38e7-46d9-903e-bda5f5b9f027.png)

_Life Coach - Before_

![screencapture-senseitheme-local-course-life-coach-2022-11-30-10_45_34](https://user-images.githubusercontent.com/1190420/204843518-ba2f741f-bf33-4bd4-b2ec-3956734ae6de.png)

_Video Hero - Before_

![screencapture-senseitheme-local-course-video-hero-2-2022-11-30-10_47_42](https://user-images.githubusercontent.com/1190420/204844004-03f49b6d-26e7-414c-a0a7-1be43eab0c4e.png)