### PR TITLE
Fix global colors not being applied to the footer

### DIFF
--- a/assets/js/footer.js
+++ b/assets/js/footer.js
@@ -1,38 +1,39 @@
-function domReady (callback) {
-  function handler () {
-      document.removeEventListener( 'DOMContentLoaded', handler, false)
-      window.removeEventListener( 'load', handler, false)
-      callback()
-  }
-  document.addEventListener( 'DOMContentLoaded', handler, false)
-  window.addEventListener( 'load', handler, false)
+function domReady ( callback ) {
+	function handler () {
+		document.removeEventListener( 'DOMContentLoaded', handler, false );
+		window.removeEventListener( 'load', handler, false );
+		callback();
+	}
+
+	document.addEventListener( 'DOMContentLoaded', handler, false );
+	window.addEventListener( 'load', handler, false );
 }
 
 let footerSiteTitle = null;
 let footerSiteTitleText = null;
 
 function calculateTextSize() {
-  const parentContainerWidth = footerSiteTitleText.parentNode.clientWidth;
-  const currentTextWidth = footerSiteTitleText.scrollWidth;
-  const currentFontSize = parseInt( window.getComputedStyle( footerSiteTitleText ).fontSize );
-  // No smaller than 16px and no larger than 500px.
-  const newValue = Math.min( Math.max( 16, ( parentContainerWidth / currentTextWidth ) * currentFontSize ), 500 )
+	const parentContainerWidth = footerSiteTitleText.parentNode.clientWidth;
+	const currentTextWidth = footerSiteTitleText.scrollWidth;
+	const currentFontSize = parseInt( window.getComputedStyle( footerSiteTitleText ).fontSize );
+	// No smaller than 16px and no larger than 500px.
+	const newValue = Math.min( Math.max( 16, ( parentContainerWidth / currentTextWidth ) * currentFontSize ), 500 );
 
-  footerSiteTitleText.style.setProperty( 'font-size', newValue + 'px' );
-  footerSiteTitle.style.height = footerSiteTitleText.offsetHeight * 0.65 + 'px';
+	footerSiteTitleText.style.setProperty( 'font-size', newValue + 'px' );
+	footerSiteTitle.style.height = footerSiteTitleText.offsetHeight * 0.65 + 'px';
 }
 
 domReady( () => {
-  footerSiteTitle = document.querySelector( 'footer .wp-block-site-title' );
-  footerSiteTitleText = document.querySelector( "footer .wp-block-site-title a" );
+	footerSiteTitle = document.querySelector( 'footer .wp-block-site-title' );
+	footerSiteTitleText = document.querySelector( 'footer .wp-block-site-title a' );
 
-  if ( ! footerSiteTitle || ! footerSiteTitleText ) {
-    return;
-  }
+	if ( ! footerSiteTitle || ! footerSiteTitleText ) {
+		return;
+	}
 
-  calculateTextSize();
+	calculateTextSize();
 
-  addEventListener( 'resize', () => {
-    calculateTextSize();
-  });
+	addEventListener( 'resize', () => {
+		calculateTextSize();
+	} );
 } );

--- a/assets/js/footer.js
+++ b/assets/js/footer.js
@@ -8,23 +8,25 @@ function domReady (callback) {
   window.addEventListener( 'load', handler, false)
 }
 
+let footerSiteTitle = null;
 let footerSiteTitleText = null;
-let footerTextContainer = null;
 
 function calculateTextSize() {
   const parentContainerWidth = footerSiteTitleText.parentNode.clientWidth;
   const currentTextWidth = footerSiteTitleText.scrollWidth;
   const currentFontSize = parseInt( window.getComputedStyle( footerSiteTitleText ).fontSize );
+  // No smaller than 16px and no larger than 500px.
   const newValue = Math.min( Math.max( 16, ( parentContainerWidth / currentTextWidth ) * currentFontSize ), 500 )
-  footerSiteTitleText.style.setProperty( 'font-size', newValue +'px');
-  footerTextContainer.style.setProperty( 'margin-block-start', ( -1 * newValue * 0.39 ) +'px');
+
+  footerSiteTitleText.style.setProperty( 'font-size', newValue + 'px' );
+  footerSiteTitle.style.height = footerSiteTitleText.offsetHeight * 0.65 + 'px';
 }
 
 domReady( () => {
+  footerSiteTitle = document.querySelector( 'footer .wp-block-site-title' );
   footerSiteTitleText = document.querySelector( "footer .wp-block-site-title a" );
-  footerTextContainer = document.querySelector("footer .course-negative-space-footer" );
 
-  if ( ! footerSiteTitleText || ! footerTextContainer ) {
+  if ( ! footerSiteTitle || ! footerSiteTitleText ) {
     return;
   }
 

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -7,8 +7,8 @@
  */
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"0px","right":"20px","left":"20px"}},"border":{"top":{"width":"1px"}}},"textColor":"foreground","layout":{"type":"constrained","contentSize":"1000px"}} -->
-<div class="wp-block-group alignfull has-foreground-color has-text-color" style="border-top-width:1px;padding-top:80px;padding-right:20px;padding-bottom:0px;padding-left:20px"><!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"40px","left":"40px"}}}} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"0px","right":"20px","left":"20px"}},"border":{"top":{"width":"1px"}}},"layout":{"type":"constrained","contentSize":"1000px"}} -->
+<div class="wp-block-group alignfull" style="border-top-width:1px;padding-top:80px;padding-right:20px;padding-bottom:0px;padding-left:20px"><!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"40px","left":"40px"}}}} -->
 <div class="wp-block-columns"><!-- wp:column {"width":"81.7%","style":{"typography":{"lineHeight":"1.3"}}} -->
 <div class="wp-block-column" style="line-height:1.3;flex-basis:81.7%"><!-- wp:columns {"style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"20px"},"blockGap":{"top":"10px","left":"20px"}}},"className":"course-footer-links-vertical-space"} -->
 <div class="wp-block-columns course-footer-links-vertical-space" style="border-left-width:1px;padding-left:20px"><!-- wp:column {"verticalAlignment":"center","width":"128px"} -->

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -7,8 +7,8 @@
  */
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"0px","right":"20px","left":"20px"}},"border":{"top":{"width":"1px"}}},"backgroundColor":"background","textColor":"foreground","layout":{"type":"constrained","contentSize":"1000px"}} -->
-<div class="wp-block-group alignfull has-foreground-color has-background-background-color has-text-color has-background" style="border-top-width:1px;padding-top:80px;padding-right:20px;padding-bottom:0px;padding-left:20px"><!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"40px","left":"40px"}}}} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"0px","right":"20px","left":"20px"}},"border":{"top":{"width":"1px"}}},"textColor":"foreground","layout":{"type":"constrained","contentSize":"1000px"}} -->
+<div class="wp-block-group alignfull has-foreground-color has-text-color" style="border-top-width:1px;padding-top:80px;padding-right:20px;padding-bottom:0px;padding-left:20px"><!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"40px","left":"40px"}}}} -->
 <div class="wp-block-columns"><!-- wp:column {"width":"81.7%","style":{"typography":{"lineHeight":"1.3"}}} -->
 <div class="wp-block-column" style="line-height:1.3;flex-basis:81.7%"><!-- wp:columns {"style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"20px"},"blockGap":{"top":"10px","left":"20px"}}},"className":"course-footer-links-vertical-space"} -->
 <div class="wp-block-columns course-footer-links-vertical-space" style="border-left-width:1px;padding-left:20px"><!-- wp:column {"verticalAlignment":"center","width":"128px"} -->
@@ -78,10 +78,10 @@
 
 <!-- wp:site-title {"textAlign":"center","style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"40px"}}},"fontFamily":"sorts-mill-goudy"} /-->
 
-<!-- wp:group {"align":"full","style":{"border":{"top":{"width":"1px"}}},"backgroundColor":"background","className":"course-negative-space-footer","layout":{"type":"constrained","contentSize":""}} -->
-<div class="wp-block-group alignfull course-negative-space-footer has-background-background-color has-background" style="border-top-width:1px"><!-- wp:paragraph {"align":"center","style":{"typography":{"letterSpacing":"0.02em"},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"backgroundColor":"background","fontSize":"x-small"} -->
+<!-- wp:group {"align":"full","style":{"border":{"top":{"width":"1px"}}},"className":"course-negative-space-footer","layout":{"type":"constrained","contentSize":""}} -->
+<div class="wp-block-group alignfull course-negative-space-footer" style="border-top-width:1px"><!-- wp:paragraph {"align":"center","style":{"typography":{"letterSpacing":"0.02em"},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"fontSize":"x-small"} -->
 
-<p class="has-text-align-center has-background-background-color has-background has-x-small-font-size" style="padding-top:80px;padding-bottom:80px;letter-spacing:0.02em">
+<p class="has-text-align-center has-x-small-font-size" style="padding-top:80px;padding-bottom:80px;letter-spacing:0.02em">
 <?php
 	echo sprintf(
 		wp_kses(

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -78,8 +78,8 @@
 
 <!-- wp:site-title {"textAlign":"center","style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"40px"}}},"fontFamily":"sorts-mill-goudy"} /-->
 
-<!-- wp:group {"align":"full","style":{"border":{"top":{"width":"1px"}}},"className":"course-negative-space-footer","layout":{"type":"constrained","contentSize":""}} -->
-<div class="wp-block-group alignfull course-negative-space-footer" style="border-top-width:1px"><!-- wp:paragraph {"align":"center","style":{"typography":{"letterSpacing":"0.02em"},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"fontSize":"x-small"} -->
+<!-- wp:group {"align":"full","style":{"border":{"top":{"width":"1px"}}},"layout":{"type":"constrained","contentSize":""}} -->
+<div class="wp-block-group alignfull" style="border-top-width:1px"><!-- wp:paragraph {"align":"center","style":{"typography":{"letterSpacing":"0.02em"},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"fontSize":"x-small"} -->
 
 <p class="has-text-align-center has-x-small-font-size" style="padding-top:80px;padding-bottom:80px;letter-spacing:0.02em">
 <?php

--- a/style.css
+++ b/style.css
@@ -377,6 +377,11 @@ footer .wp-block-column h3 {
 		gap: 10px;
 	}
 }
+
+footer h1.wp-block-site-title {
+	overflow: hidden;
+}
+
 footer h1.wp-block-site-title a {
 	display: inline-block;
 	white-space: nowrap;

--- a/style.css
+++ b/style.css
@@ -387,10 +387,6 @@ footer h1.wp-block-site-title a {
 	white-space: nowrap;
 }
 
-footer div.course-negative-space-footer {
-	position: relative;
-}
-
 /*
  * "Wide Width, No Title" page template
  */


### PR DESCRIPTION
Fixes #121.

Switch to using height + overflow instead of a negative top margin for hiding the site title "behind" the line. The margin method was dependent on having the background color of the footer hardcoded, which isn't compatible with Global Styles.

### Testing Instructions
- In the Site Editor, click on the Styles icon.
- Click on _Colors_.
- Update the _Background_, _Text_ and _Links_ colors.
- Ensure the colors are applied to the footer in both the editor and on the frontend.

### Screenshots

_Editor_

![Screenshot 2022-11-30 at 2 42 22 PM](https://user-images.githubusercontent.com/1190420/204893122-fdf40ddf-0e10-4e72-9773-b297461c0b64.jpg)

_Frontend_

![Screenshot 2022-11-30 at 2 43 34 PM](https://user-images.githubusercontent.com/1190420/204893328-29297640-47b8-458b-b11a-70d0b1c8a633.jpg)