### PR TITLE
Don't override post title's font size

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -544,9 +544,6 @@
 				}
 			},
 			"core/post-title": {
-				"typography": {
-					"fontSize": "calc(1.75*var(--wp--preset--font-size--x-large))"
-				},
 				"spacing": {
 					"margin": {
 						"bottom": "0"


### PR DESCRIPTION
Reverts the `post-title` change from [this commit](https://github.com/Automattic/course/commit/0daac6618930a319349b19f1113c9e8a315a9866). The heading elements that are used in titles should use sizes that conform to [these base styles](https://www.figma.com/file/nf4oV51c1JBxJKXshMe7cd/New-Sensei-Theme?node-id=20020042%3A412&t=6CrNHbMF0rdgnygA-0).

### Testing Instructions
- Check that post and page titles are `96px` on desktop and `48px` on mobile.
- Check that the course titles on the archive page (`http://senseitheme.local/category/uncategorized/`) are `48px`.

### Screenshots
_Archive Page - Before_

![Screenshot 2022-11-30 at 3 45 55 PM](https://user-images.githubusercontent.com/1190420/204904467-1aa68585-efcd-4aa6-89d6-b2634798a2fe.jpg)

_Archive Page - After_

![Screenshot 2022-11-30 at 3 45 14 PM](https://user-images.githubusercontent.com/1190420/204904387-cf45fd00-5c5c-481a-b6d5-9ae1523e5dba.jpg)