### PR TITLE
Fix header breaking issue in Learning Mode

### DIFF
--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -1,0 +1,5 @@
+const isFullWidthLearningModeTemplate = document.querySelector( '.sensei-course-theme__header .sensei-course-theme-course-progress-bar' );
+
+if ( isFullWidthLearningModeTemplate ) {
+    document.querySelector( 'body' ).classList.add("learning-mode-full-width");
+}

--- a/functions.php
+++ b/functions.php
@@ -67,6 +67,7 @@ if (!function_exists( 'course_scripts' )) :
 		wp_enqueue_style( 'course-sensei-learning-mode' );
 
 		// Enqueque theme scripts.
+        wp_enqueue_script( 'course-header', get_template_directory_uri() . '/assets/js/header.js', [], wp_get_theme()->get( 'Version' ), true );
 		wp_enqueue_script( 'course-footer', get_template_directory_uri() . '/assets/js/footer.js', [], wp_get_theme()->get( 'Version' ), true );
     }
 


### PR DESCRIPTION
Fixes the full width header breaking issue for Learning Mode

## Testing instructions

- Create a course with lessons
- Enable learning mode
- Access the course lesson as a student
- Make sure the header on top is taking full width as expected

## Screenshots

Before
![image](https://user-images.githubusercontent.com/6820724/205314323-c55e44d8-4d2c-44e5-9ae3-145dbc3f0a77.png)

After
![image](https://user-images.githubusercontent.com/6820724/205314453-e42be2a0-74be-4257-abcc-472625151d1b.png)