### PR TITLE
Use animation + observer to improve the footer calculation

### DIFF
--- a/assets/js/footer.js
+++ b/assets/js/footer.js
@@ -9,10 +9,8 @@ function domReady ( callback ) {
 	window.addEventListener( 'load', handler, false );
 }
 
-let footerSiteTitle = null;
-let footerSiteTitleText = null;
 
-function calculateTextSize() {
+function calculateTextSize(footerSiteTitle, footerSiteTitleText) {
 	const parentContainerWidth = footerSiteTitleText.parentNode.clientWidth;
 	const currentTextWidth = footerSiteTitleText.scrollWidth;
 	const currentFontSize = parseInt( window.getComputedStyle( footerSiteTitleText ).fontSize );
@@ -20,20 +18,30 @@ function calculateTextSize() {
 	const newValue = Math.min( Math.max( 16, ( parentContainerWidth / currentTextWidth ) * currentFontSize ), 500 );
 
 	footerSiteTitleText.style.setProperty( 'font-size', newValue + 'px' );
-	footerSiteTitle.style.height = footerSiteTitleText.offsetHeight * 0.65 + 'px';
+	footerSiteTitle.style.height = footerSiteTitleText.offsetHeight * 0.65 + 'px';  
 }
 
 domReady( () => {
-	footerSiteTitle = document.querySelector( 'footer .wp-block-site-title' );
-	footerSiteTitleText = document.querySelector( 'footer .wp-block-site-title a' );
+	const footerSiteTitle = document.querySelector( 'footer .wp-block-site-title' );
+	const footerSiteTitleText = document.querySelector( 'footer .wp-block-site-title a' );
 
-	if ( ! footerSiteTitle || ! footerSiteTitleText ) {
+	if ( !footerSiteTitle || !footerSiteTitleText) {
 		return;
 	}
 
-	calculateTextSize();
 
+	calculateTextSize(footerSiteTitle, footerSiteTitleText);
+
+	const inViewport = (entries) => {
+		entries.forEach(entry => {
+			if (entry.isIntersecting) {
+				footerSiteTitle.classList.add('is-visible');
+			}
+		});
+	};
+
+	new IntersectionObserver(inViewport).observe(footerSiteTitle)
 	addEventListener( 'resize', () => {
-		calculateTextSize();
-	} );
-} );
+		calculateTextSize(footerSiteTitle, footerSiteTitleText);
+	});
+});

--- a/assets/js/footer.js
+++ b/assets/js/footer.js
@@ -30,7 +30,7 @@ domReady( () => {
 	}
 
 
-	calculateTextSize(footerSiteTitle, footerSiteTitleText);
+	setTimeout(() => calculateTextSize(footerSiteTitle, footerSiteTitleText), 50);
 
 	const inViewport = (entries) => {
 		entries.forEach(entry => {

--- a/style.css
+++ b/style.css
@@ -326,9 +326,26 @@ a {
 }
 
 /* Footer */
+footer.wp-block-template-part {
+	margin-block-start: 0;
+}
+
 footer .wp-block-column .wp-block-spacer {
 	height: 20px;
 }
+
+
+@keyframes slideUp {
+	0% {
+		 transform: translateY(100%);
+		 opacity: 0;
+	}
+	100% {
+		transform: translateY(0);
+		opacity: 100;
+	 }
+}
+
 
 footer .wp-block-column a,
 footer .wp-block-column p,
@@ -351,6 +368,15 @@ footer .wp-block-column h3 {
 footer h1.wp-block-site-title {
 	overflow: hidden;
 }
+
+footer h1.wp-block-site-title:not(.is-visible) a {
+	transform: translateY(100%);
+}
+
+footer h1.wp-block-site-title.is-visible a {
+	animation: slideUp 0.5s;
+}
+	
 
 footer h1.wp-block-site-title a {
 	display: inline-block;


### PR DESCRIPTION
Fix [#132](https://github.com/Automattic/course/issues/132)

### Context
- Currently, the site title size is dynamic, with calculations based on the browser render, the problem is that it is happening during the rendering, which can lead our script to not calculate in the correct moment. 

#### Proposed Solution
- Postpone the initial calculation
- Use animation to hide the size recalculation. 

https://user-images.githubusercontent.com/38718/205390057-332bee39-758a-45d0-b506-0f5c56b14190.mp4

