### PR TITLE
Update default page template to be wide width

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -1,23 +1,78 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"margin":{"left":"20px","right":"20px","bottom":"80px"}}},"layout":{"type":"constrained","contentSize":"1000px"}} -->
-<div class="wp-block-group" style="margin-right:20px;margin-bottom:80px;margin-left:20px">
-
-  <!-- wp:group {"layout":{"inherit":true,"type":"constrained","contentSize":"666px","justifyContent":"left"}} -->
-  <div class="wp-block-group">
-    <!-- wp:post-title {"level":1,"style":{"typography":{"textTransform":"uppercase"}}} /-->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"layout":{"type":"constrained","contentSize":"1000px"}} -->
+<main class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+  <!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"inherit":true,"type":"constrained","contentSize":"1000px"}} -->
+  <div class="wp-block-group"
+    style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+    <!-- wp:post-title {"level":1,"align":"wide","style":{"spacing":{"margin":{"bottom":"5rem"}}}} /-->
   </div>
   <!-- /wp:group -->
 
-  <!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"style":{"spacing":{"margin":{"top":"2.5rem"}}},"layout":{"type":"constrained","contentSize":"666px","justifyContent":"left"}} -->
-  <main class="wp-block-group" style="margin-top:2.5rem">
+  <!-- wp:post-content {"layout":{"inherit":true,"contentSize":"1000px"}} /-->
 
-    <!-- wp:post-featured-image {"align":"full"} /-->
-    <!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"inherit":true},"fontFamily":"primary"} /-->
-  </main>
+  <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
+  <div class="wp-block-group">
+    <!-- wp:group {"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group">
+      <!-- wp:comments {"className":"wp-block-comments-query-loop "} -->
+      <div class="wp-block-comments wp-block-comments-query-loop">
+        <!-- wp:separator {"opacity":"css","className":"is-style-wide"} -->
+        <hr class="wp-block-separator has-css-opacity is-style-wide" />
+        <!-- /wp:separator -->
+
+        <!-- wp:comments-title {"showPostTitle":false,"showCommentsCount":false,"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"large"} /-->
+
+        <!-- wp:comment-template -->
+        <!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
+        <div class="wp-block-group">
+          <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left","verticalAlignment":"top"}} -->
+          <div class="wp-block-group">
+            <!-- wp:avatar {"size":40,"style":{"border":{"radius":"24px","width":"1px"}}} /-->
+
+            <!-- wp:group {"style":{"spacing":{"blockGap":"0","padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+            <div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+              <!-- wp:comment-author-name /-->
+
+              <!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"},"blockGap":"0.5em"}},"layout":{"type":"flex","verticalAlignment":"bottom"}} -->
+              <div class="wp-block-group" style="margin-top:0px;margin-bottom:0px">
+                <!-- wp:comment-date {"format":"F j, Y \\a\\t g:i a"} /-->
+
+                <!-- wp:comment-edit-link /-->
+              </div>
+              <!-- /wp:group -->
+
+              <!-- wp:comment-content {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} /-->
+
+              <!-- wp:comment-reply-link /-->
+            </div>
+            <!-- /wp:group -->
+          </div>
+          <!-- /wp:group -->
+
+          <!-- wp:spacer {"height":"5rem"} -->
+          <div style="height:5rem" aria-hidden="true" class="wp-block-spacer"></div>
+          <!-- /wp:spacer -->
+        </div>
+        <!-- /wp:group -->
+        <!-- /wp:comment-template -->
+
+        <!-- wp:comments-pagination -->
+        <!-- wp:comments-pagination-previous /-->
+
+        <!-- wp:comments-pagination-numbers /-->
+
+        <!-- wp:comments-pagination-next /-->
+        <!-- /wp:comments-pagination -->
+
+        <!-- wp:post-comments-form /-->
+      </div>
+      <!-- /wp:comments -->
+    </div>
+    <!-- /wp:group -->
+  </div>
   <!-- /wp:group -->
-
-</div>
+</main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/page.html
+++ b/templates/page.html
@@ -5,7 +5,7 @@
   <!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"inherit":true,"type":"constrained","contentSize":"1000px"}} -->
   <div class="wp-block-group"
     style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
-    <!-- wp:post-title {"level":1,"align":"wide","style":{"spacing":{"margin":{"bottom":"5rem"}}}} /-->
+    <!-- wp:post-title {"level":1,"align":"wide","style":{"spacing":{"margin":{"bottom":"2.5rem"}}}} /-->
   </div>
   <!-- /wp:group -->
 


### PR DESCRIPTION
Fixes issue [Update the page template to use wide + title template#136](https://github.com/Automattic/course/issues/136)

### Introduced changes
Update the page template to use the same wide + title code.

### Extra notes
Due to some unknown reason, I can't rename the theme.json, the page template to `Single Column+title`.


### Testing instructions
- Create a page
- Add a pattern with using a wide block
- Publish the page 
- Check the previous version and the new one.


### Previous
![utqimG.png](https://user-images.githubusercontent.com/38718/205395714-22292920-bc0f-4ae5-a5ca-4ef3a929d804.png)

### Updated
![3g9UOP.png](https://user-images.githubusercontent.com/38718/205395672-a2489dad-dfa6-408d-bb42-95491f46dec1.png)