### PR TITLE
Remove extra spacing between footer and the post-content

### DIFF
--- a/style.css
+++ b/style.css
@@ -348,6 +348,10 @@ footer .wp-block-column h3 {
 	}
 }
 
+footer.wp-block-template-part  {
+	margin-block-start: 0;
+}
+
 footer h1.wp-block-site-title {
 	overflow: hidden;
 }


### PR DESCRIPTION
Solves 
[Remove whitespace between testimonial and footer for landing page patterns#6215](https://github.com/Automattic/course/issues/141)

### Introduced changes
- Remove Remove extra margin between footer and the post-content


### Previous version
![5XtPfx.png](https://user-images.githubusercontent.com/38718/205401232-1733c749-0d8b-45ca-a5b1-13ebec0cf6f9.png)


### Update Version
![9Re9Q1.png](https://user-images.githubusercontent.com/38718/205401166-2c7fdb61-6d9d-4eb9-bf80-0df3fa9a59ab.png)