### PR TITLE
Remove top margin from testimonial bottom quote

### DIFF
--- a/patterns/testimonial.php
+++ b/patterns/testimonial.php
@@ -40,8 +40,8 @@
             <p class="has-x-small-font-size" style="font-style:normal;font-weight:700;letter-spacing:0.02em;line-height:1">Christopher Brown</p>
             <!-- /wp:paragraph -->
 
-            <!-- wp:paragraph {"style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"10px"}}},"fontSize":"x-small"} -->
-            <p class="has-x-small-font-size" style="padding-top:10px;letter-spacing:0.02em;line-height:1"><?php echo esc_html__( 'Founder at BeautifulWriting.com', 'course' ); ?></p>
+            <!-- wp:paragraph {"style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"10px"},"margin":{"top":"0px"}}},"className":"has-x-small-font-size","fontSize":"x-small"} -->
+            <p class="has-x-small-font-size" style="margin-top:0;padding-top:10px;letter-spacing:0.02em;line-height:1"><?php echo esc_html__( 'Founder at BeautifulWriting.com', 'course' ); ?></p>
             <!-- /wp:paragraph -->
         </div>
         <!-- /wp:column -->


### PR DESCRIPTION
Fixes https://github.com/Automattic/course/issues/133

Before:
<img width="465" alt="Screenshot 2022-12-02 at 3 58 38 PM" src="https://user-images.githubusercontent.com/3220162/205410917-6f70be43-28ad-41e4-92bc-a99907de3475.png">


After: 
<img width="612" alt="Screenshot 2022-12-02 at 3 57 13 PM" src="https://user-images.githubusercontent.com/3220162/205410797-391143df-ba57-4d92-b328-ecab33f1ab3f.png">

This only fixes it for the Testimonial Pattern, I will do a PR on Sensei for the other patterns.
