### PR TITLE
Fix site title being cut off in footer

### DIFF
--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -79,7 +79,7 @@
 <!-- wp:site-title {"textAlign":"center","style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"20px"}}},"fontFamily":"sorts-mill-goudy"} /-->
 
 <!-- wp:group {"align":"full","style":{"border":{"top":{"width":"1px"}}},"layout":{"type":"constrained","contentSize":""}} -->
-<div class="wp-block-group alignfull" style="border-top-width:1px"><!-- wp:paragraph {"align":"center","style":{"typography":{"letterSpacing":"0.02em"},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"fontSize":"x-small"} -->
+<div class="wp-block-group alignfull course-attribution" style="border-top-width:1px"><!-- wp:paragraph {"align":"center","style":{"typography":{"letterSpacing":"0.02em"},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"fontSize":"x-small"} -->
 
 <p class="has-text-align-center has-x-small-font-size" style="padding-top:80px;padding-bottom:80px;letter-spacing:0.02em">
 <?php

--- a/style.css
+++ b/style.css
@@ -336,6 +336,19 @@ footer .wp-block-column h3 {
 	white-space: nowrap;
 }
 
+footer h1.wp-block-site-title {
+	overflow: hidden;
+}
+
+footer h1.wp-block-site-title a {
+	display: inline-block;
+	white-space: nowrap;
+}
+
+footer .course-attribution {
+	margin-block-start: 0;
+}
+
 @media screen and (max-width: 480px) {
 	footer .wp-block-columns.course-footer-links-vertical-space {
 		margin-bottom: 44px;
@@ -346,15 +359,6 @@ footer .wp-block-column h3 {
 		align-items: baseline;
 		gap: 10px;
 	}
-}
-
-footer h1.wp-block-site-title {
-	overflow: hidden;
-}
-
-footer h1.wp-block-site-title a {
-	display: inline-block;
-	white-space: nowrap;
 }
 
 /*


### PR DESCRIPTION
Remove the margin from the footer attribution so that the site title isn't cut off.

### Before
![Screenshot 2022-12-03 at 5 57 11 PM](https://user-images.githubusercontent.com/1190420/205465592-6971817e-9360-46aa-8d27-584fbe9fd238.jpg)

### After
![Screenshot 2022-12-03 at 5 57 20 PM](https://user-images.githubusercontent.com/1190420/205465595-eda81fb6-0d8a-4c9f-a6a4-97c544721438.jpg)