### PR TITLE
Fix Learning Mode template styles

### DIFF
--- a/learning-mode.css
+++ b/learning-mode.css
@@ -301,10 +301,6 @@ body {
 	align-items: baseline;
 }
 
-.sensei-course-theme .sensei-course-theme__header {
-	padding-bottom: 10px;
-}
-
 .wp-block-sensei-lms-exit-course:hover {
 	text-decoration: none;
 }

--- a/learning-mode.css
+++ b/learning-mode.css
@@ -1,4 +1,4 @@
-:root, .sensei-course-theme  {
+:root, .sensei-course-theme {
 	--sensei-lm-header-height: 116px;
 	--border-color: var(--wp--preset--color--primary);
 }
@@ -11,6 +11,13 @@ body {
 
 .sensei-course-theme-course-progress-bar {
 	--border-color:  var(--border-color)
+}
+
+/* Override theme.json blockGap setting. */
+.sensei-course-theme .sensei-course-theme__sidebar,
+.sensei-course-theme__sidebar .wp-block-sensei-lms-course-navigation,
+.sensei-course-theme .is-layout-constrained > .wp-block-columns.is-layout-flex {
+	margin-block-start: 0;
 }
 
 .sensei-lms-course-navigation-lesson {
@@ -45,11 +52,11 @@ body {
 
 .sensei-lms-course-navigation-lesson__extra {
 	font-size: 1rem;
-		font-family: var(--wp--preset--font-family--system);
-		line-height: 100%;
-		font-weight: normal;
-		opacity: 1;
-		letter-spacing: 0.02em;
+	font-family: var(--wp--preset--font-family--system);
+	line-height: 100%;
+	font-weight: normal;
+	opacity: 1;
+	letter-spacing: 0.02em;
 }
 
 .sensei-lms-course-navigation-module__summary {
@@ -99,8 +106,8 @@ body {
 }
 
 .sensei-course-theme .is-style-outline .wp-block-button__link {
-		background-color: transparent;
-		border-color: var(--sensei-primary-color);
+	background-color: transparent;
+	border-color: var(--sensei-primary-color);
 }
 
 .sensei-course-theme-lesson-actions .is-secondary:hover:not(:disabled),
@@ -285,9 +292,9 @@ body {
 }
 
 .learning-mode-full-width .wp-block-sensei-lms-course-theme-course-progress-counter {
-		font-size: var(--wp--preset--font-size--x-small);
-		opacity: 1;
-		color: var(--wp--preset--color--primary) !important;
+	font-size: var(--wp--preset--font-size--x-small);
+	opacity: 1;
+	color: var(--wp--preset--color--primary) !important;
 }
 
 .sensei-lms-course-navigation-lesson {

--- a/learning-mode.css
+++ b/learning-mode.css
@@ -1,5 +1,5 @@
 :root, .sensei-course-theme  {
-  --sensei-lm-header-height: 116px;
+	--sensei-lm-header-height: 116px;
 	--border-color: var(--wp--preset--color--primary);
 }
 
@@ -45,11 +45,11 @@ body {
 
 .sensei-lms-course-navigation-lesson__extra {
 	font-size: 1rem;
-    font-family: var(--wp--preset--font-family--system);
-    line-height: 100%;
-    font-weight: normal;
-    opacity: 1;
-    letter-spacing: 0.02em;
+		font-family: var(--wp--preset--font-family--system);
+		line-height: 100%;
+		font-weight: normal;
+		opacity: 1;
+		letter-spacing: 0.02em;
 }
 
 .sensei-lms-course-navigation-module__summary {
@@ -57,9 +57,9 @@ body {
 	font-size: 11px;
 	font-weight: 400;
 	margin-top: 4px;
-  line-height: 16px;
-  opacity: 1;
-  text-transform: uppercase;
+	line-height: 16px;
+	opacity: 1;
+	text-transform: uppercase;
 }
 
 .sensei-lms-course-navigation-module__header{
@@ -75,216 +75,216 @@ body {
 }
 
 /*
-	Styles from sensei-course-theme-lesson-actions	
+	Styles from sensei-course-theme-lesson-actions
 	It was generated from https://github.com/Automattic/sensei/blob/6f93fed0b5f4abc33ddb303a1c36885ba7ca8694/assets/css/sensei-course-theme/buttons.scss#L1
 	TODO: It is already a light version from the original file, but probably is possible to reduce more.
 */
 .sensei-course-theme-lesson-actions .is-primary:not(:hover),
 .sensei-course-theme-lesson-actions .wp-block-button:not(.is-style-outline, .is-style-link):not(:hover) {
-  background-color: var(--sensei-primary-color) !important;
-  color: var(--sensei-primary-contrast-color);
+	background-color: var(--sensei-primary-color) !important;
+	color: var(--sensei-primary-contrast-color);
 }
 .sensei-course-theme-lesson-actions .is-primary:hover,
 .sensei-course-theme-lesson-actions .wp-block-button:not(.is-style-outline, .is-style-link):hover {
-  color: var(--sensei-primary-color);
-  background: none;
+	color: var(--sensei-primary-color);
+	background: none;
 }
 .sensei-course-theme-lesson-actions .is-secondary,
 .sensei-course-theme-lesson-actions .wp-block-button.is-style-outline {
-  color: var(--sensei-primary-color);
-  --wp--custom--button--border--color: var(--sensei-primary-color);
-  background-color: transparent;
+	color: var(--sensei-primary-color);
+	--wp--custom--button--border--color: var(--sensei-primary-color);
+	background-color: transparent;
 }
 
 .sensei-course-theme .is-style-outline .wp-block-button__link {
-    background-color: transparent;
-    border-color: var(--sensei-primary-color);
+		background-color: transparent;
+		border-color: var(--sensei-primary-color);
 }
 
 .sensei-course-theme-lesson-actions .is-secondary:hover:not(:disabled),
 .sensei-course-theme-lesson-actions .wp-block-button.is-style-outline:hover:not(:disabled)
 {
-  background-color: var(--sensei-primary-color) !important;
-  color: var(--sensei-primary-contrast-color);
+	background-color: var(--sensei-primary-color) !important;
+	color: var(--sensei-primary-contrast-color);
 }
 
 .sensei-course-theme-lesson-actions .is-secondary:hover:not(:disabled) .wp-block-button__link,
 .sensei-course-theme-lesson-actions .wp-block-button.is-style-outline:hover:not(:disabled) .wp-block-button__link {
-  border-color: var(--sensei-primary-color);
+	border-color: var(--sensei-primary-color);
 
 }
 .sensei-course-theme-lesson-actions .is-link {
-  font-weight: 600;
-  text-decoration: underline !important;
-  background: none !important;
-  color: inherit !important;
+	font-weight: 600;
+	text-decoration: underline !important;
+	background: none !important;
+	color: inherit !important;
 }
 .sensei-course-theme-lesson-actions .is-link:hover {
-  color: var(--sensei-primary-color) !important;
+	color: var(--sensei-primary-color) !important;
 }
 .sensei-course-theme-lesson-actions[aria-disabled=true], .sensei-course-theme-lesson-actions:disabled {
-  opacity: 0.5;
-  pointer-events: none;
-  cursor: not-allowed;
+	opacity: 0.5;
+	pointer-events: none;
+	cursor: not-allowed;
 }
 .sensei-course-theme-lesson-actions.is-completed.is-primary {
-  opacity: 0.8;
-  color: var(--bg-color) !important;
-  background: var(--text-color) !important;
-  border-color: var(--text-color) !important;
+	opacity: 0.8;
+	color: var(--bg-color) !important;
+	background: var(--text-color) !important;
+	border-color: var(--text-color) !important;
 }
 .sensei-course-theme-lesson-actions.is-completed.is-secondary {
-  opacity: 0.8;
-  color: var(--text-color) !important;
-  border-color: var(--text-color) !important;
+	opacity: 0.8;
+	color: var(--text-color) !important;
+	border-color: var(--text-color) !important;
 }
 .sensei-course-theme-lesson-actions.is-busy {
-  background-image: linear-gradient(-45deg, rgba(255, 255, 255, 0.5) 28%, rgba(255, 255, 255, 0.1) 28%, rgba(255, 255, 255, 0.1) 72%, rgba(255, 255, 255, 0.5) 72%);
-  animation: components-button__busy-animation 25000ms infinite linear;
+	background-image: linear-gradient(-45deg, rgba(255, 255, 255, 0.5) 28%, rgba(255, 255, 255, 0.1) 28%, rgba(255, 255, 255, 0.1) 72%, rgba(255, 255, 255, 0.5) 72%);
+	animation: components-button__busy-animation 25000ms infinite linear;
 }
 .sensei-course-theme-lesson-actions.is-busy:disabled {
-  cursor: not-allowed;
+	cursor: not-allowed;
 }
 .sensei-course-theme-lesson-actions .sensei-course-theme__button,
 .sensei-course-theme-lesson-actions .sensei-course-theme__link,
 .sensei-course-theme .sensei-course-theme__button,
 .sensei-course-theme .sensei-course-theme__link,
 .sensei-course-theme .wp-block-sensei-button .wp-block-button__link {
-  text-decoration: none;
-  border: solid 1px var(--sensei-primary-color);
-  display: block;
-  cursor: pointer;
-  text-transform: uppercase;
-  font-size: var(--wp--preset--font-size--small);
-  font-family: var(--wp--custom--button--typography--font-family);
-  border-radius: var(--wp--custom--button--radius);
-  padding-top: var(--wp--custom--button--spacing--padding--top);
-  padding-right: var(--wp--custom--button--spacing--padding--right);
-  padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
-  padding-left: var(--wp--custom--button--spacing--padding--left);
-  font-weight: var(--wp--custom--button--typography--font-weight);
-  letter-spacing: var(--wp--custom--button--typography--letter-spacing);
+	text-decoration: none;
+	border: solid 1px var(--sensei-primary-color);
+	display: block;
+	cursor: pointer;
+	text-transform: uppercase;
+	font-size: var(--wp--preset--font-size--small);
+	font-family: var(--wp--custom--button--typography--font-family);
+	border-radius: var(--wp--custom--button--radius);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	letter-spacing: var(--wp--custom--button--typography--letter-spacing);
 }
 .sensei-course-theme-lesson-actions .sensei-course-theme__button:focus,
 .sensei-course-theme-lesson-actions .sensei-course-theme__link:focus {
-  outline: dashed 1px var(--sensei-primary-color);
-  margin: -1px;
+	outline: dashed 1px var(--sensei-primary-color);
+	margin: -1px;
 }
 .sensei-course-theme-lesson-actions .sensei-course-theme__button.has-icon,
 .sensei-course-theme-lesson-actions .sensei-course-theme__link.has-icon {
-  display: flex;
-  gap: 4px;
-  align-items: center;
+	display: flex;
+	gap: 4px;
+	align-items: center;
 }
 .sensei-course-theme-lesson-actions .sensei-course-theme__button.has-icon svg,
 .sensei-course-theme-lesson-actions .sensei-course-theme__link.has-icon svg {
-  width: 20px;
-  height: 20px;
+	width: 20px;
+	height: 20px;
 }
 
 .sensei-lms-course-navigation-lesson__link {
-  align-items: baseline;
+	align-items: baseline;
 }
 
 .wp-block-sensei-lms-button-contact-teacher {
-  display: none;
+	display: none;
 }
 
 .sensei-course-theme .sensei-course-theme__video-container::after {
-  --sensei-lm-sidebar-width: 290px;
+	--sensei-lm-sidebar-width: 290px;
 }
 
 .sensei-course-theme .sensei-course-theme__video-container .sensei-course-theme-lesson-video .wp-block-video {
-  border: 1px solid var(--wp--preset--color--primary);
-  border-radius: 4px;
+	border: 1px solid var(--wp--preset--color--primary);
+	border-radius: 4px;
 }
 
 .sensei-course-theme .sensei-course-theme__video-container .sensei-course-theme-course-progress {
-  font-size: 11px;
-  text-transform: uppercase;
+	font-size: 11px;
+	text-transform: uppercase;
 }
 
 .sensei-course-theme__sidebar .sensei-course-theme-course-progress-bar {
-  border: 1px solid;
-  padding: 2px;
-  border-radius: 6px;
-  background-color: transparent;
-  height: auto;
+	border: 1px solid;
+	padding: 2px;
+	border-radius: 6px;
+	background-color: transparent;
+	height: auto;
 }
 
 .sensei-course-theme__sidebar .sensei-course-theme-course-progress-bar-inner {
-  border-radius: 4px;
-  height: 8px;
+	border-radius: 4px;
+	height: 8px;
 }
 
 .sensei-course-theme .sensei-course-theme__video-container {
-  border-radius: 4px;
+	border-radius: 4px;
 }
 
 .sensei-course-theme.sensei-video-lesson .sensei-course-theme__video-container .sensei-course-theme__sidebar,
 .sensei-course-theme.sensei-video-lesson .sensei-course-theme__sidebar.sensei-course-theme__secondary-sidebar {
-  border-width: 0px;
+	border-width: 0px;
 }
 
 .sensei-course-theme:not(.learning-mode-full-width) .sensei-course-theme__header > * {
-  max-width: 1240px;
-  margin-left: auto;
-  margin-right: auto;
-  width: 100%;
-  padding: 0px !important;
+	max-width: 1240px;
+	margin-left: auto;
+	margin-right: auto;
+	width: 100%;
+	padding: 0px !important;
 }
 
 .sensei-course-theme:not(.learning-mode-full-width) .sensei-course-theme__header.sensei-course-theme__frame:not(.learning-mode-full-width-header) {
-  max-width: 1240px;
-  padding-left: 20px;
-  padding-right: 20px;
+	max-width: 1240px;
+	padding-left: 20px;
+	padding-right: 20px;
 }
 
 .sensei-course-theme:not(.learning-mode-full-width) .wp-site-blocks > * {
-  max-width: 1200px;
-  margin: auto;
+	max-width: 1200px;
+	margin: auto;
 }
 
 .sensei-course-theme__header + .sensei-course-theme__columns > div:first-child.sensei-course-theme__sidebar {
-  border-radius: 0px;
-  border-width: 0px 1px 0px 0px;
-  padding-left: 20px;
-  padding-right: 20px;
+	border-radius: 0px;
+	border-width: 0px 1px 0px 0px;
+	padding-left: 20px;
+	padding-right: 20px;
 }
 
 .sensei-course-theme__sidebar {
-  --sensei-background-color:var(--wp--preset--color--background) !important;
-  background-color: var(--sensei-background-color) !important;
-  border: 1px solid var(--wp--preset--color--primary);
-  border-radius: 4px;
+	--sensei-background-color:var(--wp--preset--color--background) !important;
+	background-color: var(--sensei-background-color) !important;
+	border: 1px solid var(--wp--preset--color--primary);
+	border-radius: 4px;
 }
 
 .sensei-course-theme__sidebar > * {
-  color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--primary);
 }
 
 .sensei-lms-course-navigation + .wp-block-spacer {
-  display: none;
+	display: none;
 }
 
 .sensei-course-theme__header {
-  background-color: var(--wp--preset--color--background) !important;
-  color: var(--wp--preset--color--primary) !important;
+	background-color: var(--wp--preset--color--background) !important;
+	color: var(--wp--preset--color--primary) !important;
 }
 
 .learning-mode-full-width .wp-block-sensei-lms-course-theme-course-progress-counter {
-    font-size: var(--wp--preset--font-size--x-small);
-    opacity: 1;
-    color: var(--wp--preset--color--primary) !important;
+		font-size: var(--wp--preset--font-size--x-small);
+		opacity: 1;
+		color: var(--wp--preset--color--primary) !important;
 }
 .sensei-lms-course-navigation-lesson {
-  align-items: baseline;
+	align-items: baseline;
 }
 
 .sensei-course-theme .sensei-course-theme__header {
-  padding-bottom: 10px;
+	padding-bottom: 10px;
 }
 
 .wp-block-sensei-lms-exit-course:hover {
-  text-decoration: none;
+	text-decoration: none;
 }

--- a/learning-mode.css
+++ b/learning-mode.css
@@ -84,11 +84,13 @@ body {
 	background-color: var(--sensei-primary-color) !important;
 	color: var(--sensei-primary-contrast-color);
 }
+
 .sensei-course-theme-lesson-actions .is-primary:hover,
 .sensei-course-theme-lesson-actions .wp-block-button:not(.is-style-outline, .is-style-link):hover {
 	color: var(--sensei-primary-color);
 	background: none;
 }
+
 .sensei-course-theme-lesson-actions .is-secondary,
 .sensei-course-theme-lesson-actions .wp-block-button.is-style-outline {
 	color: var(--sensei-primary-color);
@@ -111,40 +113,47 @@ body {
 .sensei-course-theme-lesson-actions .is-secondary:hover:not(:disabled) .wp-block-button__link,
 .sensei-course-theme-lesson-actions .wp-block-button.is-style-outline:hover:not(:disabled) .wp-block-button__link {
 	border-color: var(--sensei-primary-color);
-
 }
+
 .sensei-course-theme-lesson-actions .is-link {
 	font-weight: 600;
 	text-decoration: underline !important;
 	background: none !important;
 	color: inherit !important;
 }
+
 .sensei-course-theme-lesson-actions .is-link:hover {
 	color: var(--sensei-primary-color) !important;
 }
+
 .sensei-course-theme-lesson-actions[aria-disabled=true], .sensei-course-theme-lesson-actions:disabled {
 	opacity: 0.5;
 	pointer-events: none;
 	cursor: not-allowed;
 }
+
 .sensei-course-theme-lesson-actions.is-completed.is-primary {
 	opacity: 0.8;
 	color: var(--bg-color) !important;
 	background: var(--text-color) !important;
 	border-color: var(--text-color) !important;
 }
+
 .sensei-course-theme-lesson-actions.is-completed.is-secondary {
 	opacity: 0.8;
 	color: var(--text-color) !important;
 	border-color: var(--text-color) !important;
 }
+
 .sensei-course-theme-lesson-actions.is-busy {
 	background-image: linear-gradient(-45deg, rgba(255, 255, 255, 0.5) 28%, rgba(255, 255, 255, 0.1) 28%, rgba(255, 255, 255, 0.1) 72%, rgba(255, 255, 255, 0.5) 72%);
 	animation: components-button__busy-animation 25000ms infinite linear;
 }
+
 .sensei-course-theme-lesson-actions.is-busy:disabled {
 	cursor: not-allowed;
 }
+
 .sensei-course-theme-lesson-actions .sensei-course-theme__button,
 .sensei-course-theme-lesson-actions .sensei-course-theme__link,
 .sensei-course-theme .sensei-course-theme__button,
@@ -165,17 +174,20 @@ body {
 	font-weight: var(--wp--custom--button--typography--font-weight);
 	letter-spacing: var(--wp--custom--button--typography--letter-spacing);
 }
+
 .sensei-course-theme-lesson-actions .sensei-course-theme__button:focus,
 .sensei-course-theme-lesson-actions .sensei-course-theme__link:focus {
 	outline: dashed 1px var(--sensei-primary-color);
 	margin: -1px;
 }
+
 .sensei-course-theme-lesson-actions .sensei-course-theme__button.has-icon,
 .sensei-course-theme-lesson-actions .sensei-course-theme__link.has-icon {
 	display: flex;
 	gap: 4px;
 	align-items: center;
 }
+
 .sensei-course-theme-lesson-actions .sensei-course-theme__button.has-icon svg,
 .sensei-course-theme-lesson-actions .sensei-course-theme__link.has-icon svg {
 	width: 20px;
@@ -277,6 +289,7 @@ body {
 		opacity: 1;
 		color: var(--wp--preset--color--primary) !important;
 }
+
 .sensei-lms-course-navigation-lesson {
 	align-items: baseline;
 }


### PR DESCRIPTION
Fixes #143.

This removes the extra whitespace from the progress bar in the Modern and Video templates.

It also fixes the gap between the course outline separator and the progress bar in the Default template.


### Testing Instructions
- Add a Featured Video block to a lesson.
- View the lesson in the Modern, Video and Default templates.
- Ensure there isn't excess whitespace above and below the progress bar in the Modern and Video templates.
- Ensure the course outline separator intersects with the progress bar in the Default template.

#### Modern
![Screenshot 2022-12-04 at 5 52 19 PM](https://user-images.githubusercontent.com/1190420/205520387-ecc97e38-f211-48da-a9b8-014468fa4078.jpg)

#### Video
![Screenshot 2022-12-04 at 5 53 42 PM](https://user-images.githubusercontent.com/1190420/205520443-40a03438-edab-414b-9940-3b5fe952bc63.jpg)

#### Default
![Screenshot 2022-12-04 at 5 48 54 PM](https://user-images.githubusercontent.com/1190420/205520234-66813eb7-3310-4f32-93ec-ce63524945ee.jpg)