### PR TITLE
Make spacing and borders consistent on search results page

### DIFF
--- a/style.css
+++ b/style.css
@@ -234,6 +234,19 @@ a {
 	padding: 1.063rem;
 }
 
+/*
+ * Search Results Styles
+ */
+.search .is-layout-flow li {
+	margin-top: 0;
+}
+
+.search .wp-block-post.course.type-course {
+	margin:0;
+	padding: 0;
+	border-bottom: 0;
+}
+
 /* Buttons */
 .wp-block-button__link:focus {
 	outline: var(--wp--preset--color--foreground) dashed;

--- a/style.css
+++ b/style.css
@@ -237,14 +237,14 @@ a {
 /*
  * Search Results Styles
  */
-.search .is-layout-flow li {
-	margin-top: 0;
+.search .wp-block-post-template .wp-block-post {
+	margin: 0;
 }
 
-.search .wp-block-post.course.type-course {
-	margin:0;
-	padding: 0;
+.search .wp-block-post.course {
 	border-bottom: 0;
+	margin: 0;
+	padding: 0;
 }
 
 /* Buttons */


### PR DESCRIPTION
Fixes https://github.com/Automattic/course/issues/116

Previously, Courses had a bottom border, and the spacing between Pages/Posts/Courses was not consistent.

Before:
<img width="700" alt="Screenshot 2022-12-04 at 4 20 31 PM" src="https://user-images.githubusercontent.com/3220162/205524830-66f225c8-effb-46f6-a06e-596332b0bb30.png">

After:
<img width="820" alt="Screenshot 2022-12-04 at 4 20 52 PM" src="https://user-images.githubusercontent.com/3220162/205524869-a840c12b-6288-44d4-ac9a-38121da2e2ae.png">

Now, between each result there is 88 pixels in space:
<img width="513" alt="Screenshot 2022-12-04 at 4 22 03 PM" src="https://user-images.githubusercontent.com/3220162/205524934-b25c3a14-4b20-4072-87d3-22609c9e48a0.png">

The only exception I have seen is when you have a result that has no "content" in the body, it then becomes a little smaller.  I think that's ok though, since the difference comes from not accounting for the extra padding that a `p` element would add, and most likely most pages and posts will have content.

<img width="391" alt="Screenshot 2022-12-04 at 4 22 45 PM" src="https://user-images.githubusercontent.com/3220162/205525005-4ec02ed3-b915-493e-908a-e8ddddc15c2b.png">

