### PR TITLE
Fix quiz footer not full width

### DIFF
--- a/learning-mode.css
+++ b/learning-mode.css
@@ -245,6 +245,10 @@ body {
   margin: auto;
 }
 
+.sensei-course-theme:not(.learning-mode-full-width) .sensei-course-theme__quiz__footer__wrapper {
+  max-width: 100%;
+}
+
 .sensei-course-theme__header + .sensei-course-theme__columns > div:first-child.sensei-course-theme__sidebar {
   border-radius: 0px;
   border-width: 0px 1px 0px 0px;


### PR DESCRIPTION
This fixes the footer not filling the width of the browser.

### Testing Instructions
- Set the LM template to Default.
- Add a quiz and a few questions to a lesson.
- Set Pagination to "Multi-page".
- View the quiz on the front-end.
- Ensure the footer extends the width of the page.
- Repeat for the other LM templates.

### Screenshot
![Screenshot 2022-12-05 at 8 49 59 AM](https://user-images.githubusercontent.com/1190420/205653271-5f795abc-d47b-4c31-97bc-83abbec792ad.jpg)