### PR TITLE
Remove right margin from post content in small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -402,3 +402,12 @@ body.page-template-page-wide-width footer .wp-block-group {
 .wp-block-social-links .wp-block-social-link .wp-block-social-link-anchor svg {
 	color: var(--wp--preset--color--primary);
 }
+
+/*
+ * Mobile Styles
+ */
+ @media ( max-width: 781px ) {
+	.single-post .is-layout-flow {
+		margin-right: 0 !important;
+	}
+ }


### PR DESCRIPTION
Fixes https://github.com/Automattic/themes/issues/6976

I had to use `!important` because the margin is defined in the HTML here: https://github.com/Automattic/course/blob/trunk/templates/single.html#L18

Before:
<img width="582" alt="Screenshot 2022-12-05 at 10 53 56 AM" src="https://user-images.githubusercontent.com/3220162/205719557-1d944797-4231-411b-9924-9d1dffd53d50.png">

After:
<img width="598" alt="Screenshot 2022-12-05 at 10 54 19 AM" src="https://user-images.githubusercontent.com/3220162/205719579-e89aacfe-6d36-430b-b8a4-99a575516e80.png">
