### PR TITLE
Fix comments reply header font size and style

### DIFF
--- a/style.css
+++ b/style.css
@@ -213,6 +213,13 @@ header.wp-block-template-part {
 	gap: 0;
 }
 
+.comment-respond h3#reply-title {
+	font-family: var(--wp--preset--font-family--system);
+	text-transform: none;
+	margin-bottom: 40px;
+	font-weight: 600;
+}
+
 /*
  * Link styles
  */


### PR DESCRIPTION
Fixes https://github.com/Automattic/themes/issues/6977

Before:
<img width="769" alt="Screenshot 2022-12-05 at 2 52 05 PM" src="https://user-images.githubusercontent.com/3220162/205760363-fdec00c3-f61c-4ec9-8377-f82f70a2b7c8.png">

After:
<img width="717" alt="Screenshot 2022-12-05 at 2 51 56 PM" src="https://user-images.githubusercontent.com/3220162/205760387-aaea4369-196d-4b65-a454-9802bc6abb70.png">
