### PR TITLE
Use p instead of heading tag on site footer

### DIFF
--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -113,7 +113,7 @@
       <div class="wp-block-group">
         <!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained","contentSize":"1000px","justifyContent":"center"}} -->
         <div class="wp-block-group">
-          <!-- wp:site-title {"textAlign":"left","isLink":false,"style":{"typography":{"letterSpacing":"0.02em","fontSize":"100px","lineHeight":"1"},"spacing":{"margin":{"top":"0px"},"padding":{"top":"0px"}}},"className":"footer-title","fontFamily":"sorts-mill-goudy"} /-->
+          <!-- wp:site-title {"level":0,"textAlign":"left","isLink":false,"style":{"typography":{"letterSpacing":"0.02em","fontSize":"100px","lineHeight":"1"},"spacing":{"margin":{"top":"0px"},"padding":{"top":"0px","left":"0"}}},"className":"footer-title","fontFamily":"sorts-mill-goudy"} /-->
         </div>
         <!-- /wp:group -->
       </div>

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -113,7 +113,7 @@
       <div class="wp-block-group">
         <!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained","contentSize":"1000px","justifyContent":"center"}} -->
         <div class="wp-block-group">
-          <!-- wp:site-title {"level":0,"textAlign":"left","isLink":false,"style":{"typography":{"letterSpacing":"0.02em","fontSize":"100px","lineHeight":"1"},"spacing":{"margin":{"top":"0px"},"padding":{"top":"0px","left":"0"}}},"className":"footer-title","fontFamily":"sorts-mill-goudy"} /-->
+          <!-- wp:site-title {"level":0,"textAlign":"left","isLink":false,"style":{"typography":{"letterSpacing":"0.02em","fontSize":"100px","lineHeight":"1"},"spacing":{"margin":{"top":"0px"},"className":"footer-title","fontFamily":"sorts-mill-goudy"} /-->
         </div>
         <!-- /wp:group -->
       </div>


### PR DESCRIPTION
Part of #132 
### Introduced change
- Update the footer to a paragraph instead of a heading tag due to SEO requirements.

### Testing instructions
- Go to the branch
- Check if the site title on the footer is using a paragraph instead of h1