### PR TITLE
Add more theme tags

### DIFF
--- a/style.css
+++ b/style.css
@@ -10,7 +10,7 @@ Requires PHP: 7.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: course
-Tags: lms, eLearning, teach, online courses, sensei
+Tags: block-patterns, eLearning, education, full-site-editing, lms, online courses, sensei, teach, translation-ready
 */
 
 /*


### PR DESCRIPTION
Fixes #157.

Adds some additional tags as defined [here](https://make.wordpress.org/themes/handbook/review/required/theme-tags/).