### PR TITLE
Don't hide Contact Teacher block

### DIFF
--- a/learning-mode.css
+++ b/learning-mode.css
@@ -205,10 +205,6 @@ body {
 	align-items: baseline;
 }
 
-.wp-block-sensei-lms-button-contact-teacher {
-	display: none;
-}
-
 .sensei-course-theme .sensei-course-theme__video-container::after {
 	--sensei-lm-sidebar-width: 290px;
 }


### PR DESCRIPTION
Fixes #155.

We shouldn't be hiding the Contact Teacher block, so this PR fixes that.

### Testing Instructions
- Enable Learning Mode.
- Add the Contact Teacher block to a course or lesson.
- Ensure the Contact Teacher block is visible in the editor and on the frontend.