### PR TITLE
Adjust font sizes to be responsive

### DIFF
--- a/styles/blue.json
+++ b/styles/blue.json
@@ -44,7 +44,7 @@
 		"custom": {
 			"typography": {
 				"fontSizes": {
-					"normal": "1.125rem",
+					"normal": "clamp(1rem, 0.911rem + 0.238vw, 1.125rem)",
 					"button": "1.125rem"
 				}
 			}

--- a/styles/dark.json
+++ b/styles/dark.json
@@ -44,7 +44,7 @@
 		"custom": {
 			"typography": {
 				"fontSizes": {
-					"normal": "1.25rem",
+					"normal": "clamp(1.125rem, 1.036rem + 0.238vw, 1.25rem)",
 					"button": "1.125rem"
 				}
 			}

--- a/styles/gold.json
+++ b/styles/gold.json
@@ -44,7 +44,7 @@
 		"custom": {
 			"typography": {
 				"fontSizes": {
-					"normal": "1.25rem",
+					"normal": "1.125rem",
 					"button": "1rem"
 				}
 			}

--- a/theme.json
+++ b/theme.json
@@ -128,7 +128,7 @@
 		"custom": {
 			"typography": {
 				"fontSizes": {
-					"normal": "1.5rem",
+					"normal": "clamp(1.313rem, 1.179rem + 0.357vw, 1.5rem)",
 					"button": "1.3125rem"
 				}
 			},
@@ -296,7 +296,7 @@
 					"size": "1.375rem",
 					"fluid": {
 						"min": "1.25rem",
-						"max": "1.75rem"
+						"max": "1.5rem"
 					},
 					"slug": "medium"
 				},
@@ -329,7 +329,7 @@
 				},
 				{
 					"name": "Gigantic",
-					"size": "16.125rem",
+					"size": "22.125rem",
 					"fluid": {
 						"min": "16.125rem",
 						"max": "28.125rem"


### PR DESCRIPTION
Fixes #115.

This PR adjusts some font sizes across all variations for mobile and desktop:

### Default Variation
- Body font size is `21px` on mobile and `24px` on desktop.
- Font size of `h4` is `20px` on mobile and `24px` on desktop.

### Blue Variation
- Body font size is `16px` on mobile and `18px` on desktop.

### Dark Variation
- Body font size is `18px` on mobile and `20px` on desktop.

### Gold Variation
- Body font size is `18px` on mobile and `18px` on desktop.

### Testing Instructions
- Add a paragraph block and a heading block to a page. Set the heading to `h4`. 
- Check that the font sizes are as above in both the editor and frontend on mobile and desktop.
- Check the other variations to ensure the body font size is correct for those as well.

For reference, the designs I used are [here](https://www.figma.com/file/nf4oV51c1JBxJKXshMe7cd/New-Sensei-Theme?node-id=20021039%3A14926&t=Pc7V15HYMv7i5BgU-0) and [here](https://www.figma.com/file/nf4oV51c1JBxJKXshMe7cd/New-Sensei-Theme?node-id=20021039%3A20067&t=Pc7V15HYMv7i5BgU-0).