### PR TITLE
Revert "Use p instead of heading tag on site footer"

### DIFF
--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -113,7 +113,7 @@
       <div class="wp-block-group">
         <!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained","contentSize":"1000px","justifyContent":"center"}} -->
         <div class="wp-block-group">
-          <!-- wp:site-title {"level":0,"textAlign":"left","isLink":false,"style":{"typography":{"letterSpacing":"0.02em","fontSize":"100px","lineHeight":"1"},"spacing":{"margin":{"top":"0px"},"className":"footer-title","fontFamily":"sorts-mill-goudy"} /-->
+          <!-- wp:site-title {"textAlign":"left","isLink":false,"style":{"typography":{"letterSpacing":"0.02em","fontSize":"100px","lineHeight":"1"},"spacing":{"margin":{"top":"0px"},"padding":{"top":"0px"}}},"className":"footer-title","fontFamily":"sorts-mill-goudy"} /-->
         </div>
         <!-- /wp:group -->
       </div>


### PR DESCRIPTION
Reverts Automattic/course#154

Reverting because I get the following warnings (plus a few others):

![Screenshot 2023-01-12 at 11 15 19 AM](https://user-images.githubusercontent.com/1190420/212121555-34ad6486-d555-4be3-bb82-18990899d2b0.jpg)