### PR TITLE
Remove text color from learning mode lesson titles

### DIFF
--- a/learning-mode.css
+++ b/learning-mode.css
@@ -35,7 +35,6 @@ body {
 
 .sensei-lms-course-navigation-lesson__title {
 	font-family: var(--wp--preset--font-family--system);
-	color: var(--wp--preset--color--primary);
 	font-size: 1rem;
 	font-weight: normal;
 }


### PR DESCRIPTION
## Problem

When trying to edit the Lesson Title in Learning Mode, it's not possible to do so because the Course theme overrides the color with CSS.

If we remove this color CSS, the default color remains the same but now you are able to edit the Lesson title with the Site Editor.

## Testing
1. Create a Course with lessons
2. Make sure Learning Mode is active
3. Go to the site editor
4. Select the Learning Mode template
5. Edit the Lesson text color
6. Make sure you see it both in the Editor and in the Frontend
7. Make sure to test with every different Learning Mode template

Site Editor:
<img width="1318" alt="Screenshot 2023-01-23 at 2 01 24 PM" src="https://user-images.githubusercontent.com/3220162/214159773-0bce1a68-dbcc-4d8d-aa8c-e73e2544c32c.png">

Frontend:
<img width="492" alt="Screenshot 2023-01-23 at 2 01 29 PM" src="https://user-images.githubusercontent.com/3220162/214159804-e1ed6d5f-3765-40a5-b3dd-3d0ef25631ce.png">
