### PR TITLE
Improve the glossary style

### DIFF
--- a/style.css
+++ b/style.css
@@ -399,6 +399,12 @@ body.page-template-page-wide-width footer .wp-block-group {
 	text-transform: uppercase;
 }
 
+/* Glossary */
+.sensei-glossary-tooltip .sensei-glossary-tooltip__inner {
+	background-color: var(--wp--preset--color--background);
+	border-color: var(--wp--preset--color--foreground);
+}
+
 /*
  * Style Variations
  */


### PR DESCRIPTION
This PR changes the background and border colors of the glossary to make it look nicer.

### Testing Instructions

* To enable the glossary, checkout the `release/sensei-pro-1.11.0` Sensei Pro branch.
* Create a glossary entry.
* Create a lesson and add the glossary phrase to the content.
* View the lesson in the front-end and make sure the glossary styles are applied.

### Screenshots

![image](https://user-images.githubusercontent.com/1612178/215573177-8fd02cfd-861d-436e-9855-dc4fde1b833c.png)

