### PR TITLE
Fix global background and text colors in Learning Mode

### DIFF
--- a/learning-mode.css
+++ b/learning-mode.css
@@ -190,7 +190,7 @@ body {
 
 .sensei-course-theme .sensei-course-theme__video-container .sensei-course-theme-lesson-video .wp-block-video {
 	border: 1px solid var(--wp--preset--color--primary);
-	border-radius: 4px;
+	border-radius: 3px;
 }
 
 .sensei-course-theme .sensei-course-theme__video-container .sensei-course-theme-course-progress {

--- a/learning-mode.css
+++ b/learning-mode.css
@@ -1,16 +1,10 @@
 :root, .sensei-course-theme {
 	--sensei-lm-header-height: 116px;
-	--border-color: var(--wp--preset--color--primary);
 }
 
 body {
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
-	---border-color: var(--border-color, red)
-}
-
-.sensei-course-theme-course-progress-bar {
-	--border-color:  var(--border-color)
 }
 
 /* Override theme.json blockGap setting. */
@@ -45,7 +39,6 @@ body {
 	line-height: 100%;
 	letter-spacing: 0.01em;
 	text-transform: uppercase;
-	color: var(--wp--preset--color--foreground);
 	text-decoration: none;
 }
 
@@ -138,19 +131,6 @@ body {
 	cursor: not-allowed;
 }
 
-.sensei-course-theme-lesson-actions.is-completed.is-primary {
-	opacity: 0.8;
-	color: var(--bg-color) !important;
-	background: var(--text-color) !important;
-	border-color: var(--text-color) !important;
-}
-
-.sensei-course-theme-lesson-actions.is-completed.is-secondary {
-	opacity: 0.8;
-	color: var(--text-color) !important;
-	border-color: var(--text-color) !important;
-}
-
 .sensei-course-theme-lesson-actions.is-busy {
 	background-image: linear-gradient(-45deg, rgba(255, 255, 255, 0.5) 28%, rgba(255, 255, 255, 0.1) 28%, rgba(255, 255, 255, 0.1) 72%, rgba(255, 255, 255, 0.5) 72%);
 	animation: components-button__busy-animation 25000ms infinite linear;
@@ -234,11 +214,6 @@ body {
 
 .sensei-course-theme .sensei-course-theme__video-container {
 	border-radius: 4px;
-}
-
-.sensei-course-theme.sensei-video-lesson .sensei-course-theme__video-container .sensei-course-theme__sidebar,
-.sensei-course-theme.sensei-video-lesson .sensei-course-theme__sidebar.sensei-course-theme__secondary-sidebar {
-	border-width: 0px;
 }
 
 .sensei-course-theme:not(.learning-mode-full-width) .sensei-course-theme__header > * {

--- a/learning-mode.css
+++ b/learning-mode.css
@@ -218,12 +218,13 @@ body {
 	text-transform: uppercase;
 }
 
+/* Progress bar in Modern and Video templates. */
 .sensei-course-theme__sidebar .sensei-course-theme-course-progress-bar {
-	border: 1px solid;
-	padding: 2px;
-	border-radius: 6px;
 	background-color: transparent;
+	border: 1px solid;
+	border-radius: 6px;
 	height: auto;
+	padding: 2px;
 }
 
 .sensei-course-theme__sidebar .sensei-course-theme-course-progress-bar-inner {
@@ -270,30 +271,19 @@ body {
 	padding-right: 20px;
 }
 
-.sensei-course-theme__sidebar:not(.sensei-course-theme__secondary-sidebar) {
-	--sensei-background-color:var(--wp--preset--color--background) !important;
-	background-color: var(--sensei-background-color) !important;
+/* Sidebar on Modern template */
+.sensei-modern .sensei-course-theme__sidebar:not(.sensei-course-theme__secondary-sidebar) {
 	border: 1px solid var(--wp--preset--color--primary);
 	border-radius: 4px;
-}
-
-.sensei-course-theme__sidebar > * {
-	color: var(--wp--preset--color--primary);
 }
 
 .sensei-lms-course-navigation + .wp-block-spacer {
 	display: none;
 }
 
-.sensei-course-theme__header {
-	background-color: var(--wp--preset--color--background) !important;
-	color: var(--wp--preset--color--primary) !important;
-}
-
 .learning-mode-full-width .wp-block-sensei-lms-course-theme-course-progress-counter {
 	font-size: var(--wp--preset--font-size--x-small);
 	opacity: 1;
-	color: var(--wp--preset--color--primary) !important;
 }
 
 .sensei-lms-course-navigation-lesson {

--- a/learning-mode.css
+++ b/learning-mode.css
@@ -246,10 +246,17 @@ body {
 	padding-right: 20px;
 }
 
-/* Sidebar on Modern template */
+/* Modern Template */
 .sensei-modern .sensei-course-theme__sidebar:not(.sensei-course-theme__secondary-sidebar) {
-	border: 1px solid var(--wp--preset--color--primary);
+	border: 1px solid var(--sensei-text-color);
 	border-radius: 4px;
+}
+
+/* Modern Template */
+.sensei-course-theme.sensei-modern .sensei-course-theme__header,
+.sensei-course-theme.sensei-modern .sensei-course-theme__sidebar {
+	background-color: var(--sensei-background-color);
+	color: var(--sensei-text-color);
 }
 
 .sensei-lms-course-navigation + .wp-block-spacer {


### PR DESCRIPTION
Partial fix for https://github.com/Automattic/sensei-pro/issues/2115.

This PR fixes the header and sidebar of the Learning Mode templates not picking up global colors. Note that we should avoid using `!important` as it makes it impossible for global styles to be used.

The following PRs can also be tested as part of this PR:
- Switch to this Sensei branch (make sure you run `npm run build`) - https://github.com/Automattic/sensei/pull/6547
- Switch to this Sensei Pro branch (make sure you run `npm run build`) - https://github.com/Automattic/sensei-pro/pull/2125

This PR also removes some obsolete CSS that wasn't being applied at all.

### Testing Instructions
1. Ensure Learning Mode is enabled.
2. In the site editor, open the _Styles_ sidebar.
3. Click on _Colors_ and update the _Background_ and _Text_ colors.
4. Browse to the frontend and open a lesson.
5. Check that the header and sidebar are using the correct background and text colors.
6. Test that the colors of the progress bar and the module names in the sidebar respect the _Text_ color (https://github.com/Automattic/sensei/pull/6547).
7. Repeat for all Learning Mode templates. (The Modern template needs https://github.com/Automattic/sensei-pro/pull/2125 in order to work.)

Note: This PR only fixes the _Background_ and _Text_ colors. Separate PRs will be needed to address the issues with the rest of the elements (i.e. links, headings, buttons).