### PR TITLE
Fix the path used for the Inter font

### DIFF
--- a/styles/blue.json
+++ b/styles/blue.json
@@ -139,7 +139,7 @@
 							"fontWeight": "400",
 							"fontStyle": "normal",
 							"fontStretch": "normal",
-							"src": [ "file:./assets/Inter-VariableFont_slnt,wght.ttf" ]
+							"src": [ "file:./assets/fonts/Inter-VariableFont_slnt,wght.ttf" ]
 						},
 						{
 							"fontFamily": "Inter",
@@ -147,7 +147,7 @@
 							"fontWeight": "700",
 							"fontStyle": "normal",
 							"fontStretch": "normal",
-							"src": [ "file:./assets/Inter-VariableFont_slnt,wght.ttf" ]
+							"src": [ "file:./assets/fonts/Inter-VariableFont_slnt,wght.ttf" ]
 						}
 					]
 				},

--- a/theme.json
+++ b/theme.json
@@ -254,7 +254,7 @@
 							"fontWeight": "400",
 							"fontStyle": "normal",
 							"fontStretch": "normal",
-							"src": [ "file:./assets/Inter-VariableFont_slnt,wght.ttf" ]
+							"src": [ "file:./assets/fonts/Inter-VariableFont_slnt,wght.ttf" ]
 						},
 						{
 							"fontFamily": "Inter",
@@ -262,7 +262,7 @@
 							"fontWeight": "700",
 							"fontStyle": "normal",
 							"fontStretch": "normal",
-							"src": [ "file:./assets/Inter-VariableFont_slnt,wght.ttf" ]
+							"src": [ "file:./assets/fonts/Inter-VariableFont_slnt,wght.ttf" ]
 						}
 					]
 				},


### PR DESCRIPTION
This is making upsells in Sensei LMS look bad.

### Changes Proposed
- Fix the path to the Inter font.

### Testing Instructions
- Ensure you're on the `Blue` or `Default` style and have enabled the Gutenberg plugin active to reproduce the issue with the upsells.
- Use the font in a block and ensure it is loaded correctly without any 404s in the browser's network inspector.
- With Sensei Pro deactivated, go to the Groups page (upsell). Also ensure no 404s in the browser and the upsell looks like this:
![Screenshot 2023-03-21 at 1 58 46 pm](https://user-images.githubusercontent.com/68693/226629049-de002254-d0d2-4587-ba6b-54a2bcf6dad4.png)

And **NOT** like this:
![Screenshot 2023-03-21 at 1 59 21 pm](https://user-images.githubusercontent.com/68693/226629226-38d45dae-127c-4b1f-afaf-28e05ef29f09.png)
